### PR TITLE
Angular Aria dependency version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   "private": true,
   "dependencies": {
     "angular": "1.4.2",
+    "angular-aria": "1.4.2",
     "angular-mocks": "1.4.2",
     "angular-animate": "1.4.2",
     "angular-material": "0.10.0",


### PR DESCRIPTION
Specified version to 1.4.2 - it was defaulting to 1.4.3 and causing a conflict on install.