### PR TITLE
Use LDAPS instead of LDAP so the channel between our server and LDAP is encrypted

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "mkdirs": "0.0.2",
     "mongodb": "2.0.45",
     "passport": "0.1.15",
-    "passport-windowsauth": "git://github.com/auth0/passport-windowsauth.git#11b5a7c"
+    "passport-windowsauth": "git://github.com/Mctalian/passport-windowsauth.git#v0.5.1"
   }
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -36,6 +36,8 @@ module.exports = function(app) {
     }
 
     app.post('/login', function handleAuthentication(req, res, next) {
+        process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
         if (process.env.NODE_ENV !== 'production') {
             if (new Buffer(req.body.password, "base64").toString() === 'test') {
                 users.findForLogin(req.body.username, function(err, responseObj) {


### PR DESCRIPTION
Much like HTTP vs. HTTPS, we also want to use LDAPS in favor of LDAP.

Need to update ldapAuth.js slightly as well on your local machine if you want to run production.

I updated the Internal FAQ board: https://trello.com/b/V1pEx3H3/flint-and-steel-internal-faq

Basically, I had to change the passport-windowsauth library we were using to use a newer version of the node-ldapjs library. I have a PR up, but I don't think it will get accepted. In the meantime, we will use the version on my fork.

Also had to set the `NODE_TLS_REJECT_UNAUTHORIZED` to "0" because it's a self-signed certificate (I think that's why).

@alanlgirard, @YashdalfTheGray, @davethenipper, @bcbrennecke 

Whichever of you gets to it first and second. Pretty easy changes.