### PR TITLE
Concurrency Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Any changes to the code while the server is running will result in a server rest
 
 To run the client side tests, execute `gulp test:client` from a terminal window. This automatically runs when a `gulp start:dev` or `gulp start:prod` command is executed.
 
+To run the server load tests, execute `gulp start:test` from a terminal window then open an additional terminal window and enter `gulp test:load`. This will submit a number of ideas to the server and provide timing statistics in milliseconds to the terminal window.
+
 ### Linting and style check
 
 Running `gulp jshint` will lint any JavaScript file under the `src` folder excluding `src/lib` and `server` as well as `gulpfile.js`.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Running the server in development mode disables LDAP login and HTTPS and falls b
 
 In order to run the server in production mode, you need to have access to the company network for LDAP purposes. You also need to create  `server\secrets\ldapAuth.js` which will hold the credentials needed to bind to the LDAP server. Lastly, you will need to have certificates to run HTTPS. Please look up self-signed certificates in order to properly set up the production environment, or obtain certificates from a trusted Certificate Authority.
 
-Any changes to the code while the server is running will result in a server restart. However, this **DOES NOT** automatically re-run client tests or JavaScript analysis commands, so be sure to run them yourself before submitting a PR.
+Any changes to the back-end server code while the server is running will result in a server restart. However, this **DOES NOT** automatically re-run client tests or JavaScript analysis commands, so be sure to run them yourself before submitting a PR.
+
+Any changes to the front-end client code will not result in a server restart. You will, however, need to perform a hard-refresh in your browser window to pick up the changes.
 
 `gulp start:test` will run the server in the test environment. This is identical to `dev`, but it uses a hard-coded port number of `7357` and does not generate data.
 

--- a/database-schema.json
+++ b/database-schema.json
@@ -7,10 +7,7 @@
         "username": "",
         "email": "",
         "nickname": "",
-        "title": "",
-        "likedIdeas": [
-            "set of idea._ids"
-        ]
+        "title": ""
     },
     "idea": {
         "_id": "mongo_generated",

--- a/database-schema.json
+++ b/database-schema.json
@@ -7,7 +7,10 @@
         "username": "",
         "email": "",
         "nickname": "",
-        "title": ""
+        "title": "",
+        "likedIdeas": [
+            "set of idea._ids"
+        ]
     },
     "idea": {
         "_id": "mongo_generated",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -138,7 +138,10 @@ gulp.task('start:dev', ['test:client', 'inject', 'generate:data'], function() {
     nodemon({
         script: 'server/server.js',
         env: { 'NODE_ENV': 'development' },
-        'ignore': ['server/datastore/*']
+        'ignore': [
+            'server/datastore/*',
+            'src/*'
+        ]
     });
 });
 
@@ -148,7 +151,10 @@ gulp.task('start:test', ['test:client', 'inject'], function() {
     nodemon({
         script: 'server/server.js',
         env: { 'NODE_ENV': 'test' },
-        'ignore': ['server/datastore/*']
+        'ignore': [
+            'server/datastore/*',
+            'src/*'
+        ]
     });
 });
 
@@ -158,7 +164,10 @@ gulp.task('start:prod', ['test:client', 'inject'], function() {
     nodemon({
         script: 'server/server.js',
         env: { 'NODE_ENV': 'production' },
-        'ignore': ['server/datastore/*']
+        'ignore': [
+            'server/datastore/*',
+            'src/*'
+        ]
     });
 });
 

--- a/server/db.js
+++ b/server/db.js
@@ -175,6 +175,34 @@ module.exports = function(dbName, cb) {
         );
     };
 
+    module.updateOneArrayElement = function updateArrayElement(collection, id, property, searchProperty, searchValue, newValue, cb) {
+        var objId = new ObjectId(id);
+
+        var query = {};
+        query._id = objId;
+        query[property + "." + searchProperty] = searchValue; // Find the old value
+
+        var update = {};
+        update.$set = {};
+        // '.$' Update first match of query (should be only match)
+        update.$set[property + ".$"] = newValue;
+
+        db.collection(collection).updateOne(
+            query,
+            update,
+            function(err, results) {
+                if (err) {
+                    console.error(chalk.bgRed(err));
+                    cb(err);
+                }
+                else {
+                    // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), id);
+                    cb(null, results);
+                }
+            }
+        );
+    };
+
     module.updateOnePullArray = function updateOnePushArray(collection, id, property, value, cb) {
 
         var objId = new ObjectId(id);

--- a/server/db.js
+++ b/server/db.js
@@ -175,6 +175,32 @@ module.exports = function(dbName, cb) {
         );
     };
 
+    module.updateOnePullArray = function updateOnePushArray(collection, id, property, value, cb) {
+
+        var objId = new ObjectId(id);
+
+        var update = {};
+        update[property] = value;
+
+        var pull = {};
+        pull.$pull = update;
+
+        db.collection(collection).updateOne(
+            { _id: objId },
+            pull,
+            function(err, results) {
+                if (err) {
+                    console.error(chalk.bgRed(err));
+                    cb(err);
+                }
+                else {
+                    // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), id);
+                    cb(null, results);
+                }
+            }
+        );
+    };
+
     module.findAndPullArray = function findAndPullArray(collection, property, value, cb) {
         var find = {};
         find[property] = value;

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -140,8 +140,7 @@ module.exports = function(db) {
             setTimeout(function() {
                 ideaProto.emit("newHeaders", newestHeaders);
                 isEmittingHeaders = false;
-            }
-            , 500);
+            }, 500);
         }
     };
 
@@ -168,8 +167,7 @@ module.exports = function(db) {
             setTimeout(function() {
                 ideaProto.emit("updateIdea_" + key, idea);
                 isEmittingUpdates = false;
-            }
-            , 500);
+            }, 500);
         }
     };
 

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -29,8 +29,10 @@ module.exports = function(db) {
     };
 
     module.like = function(id, userId, cb) {
+        var objId = new ObjectId(userId);
+
         var obj = {
-            userId: userId
+            userId: objId
         };
         db.updateOnePushArray(COLLECTION, id, "likes", obj, cb);
     };
@@ -42,9 +44,7 @@ module.exports = function(db) {
             userId: objId
         };
 
-        db.findAndPullArray(COLLECTION, "likes", obj, function(err, results) {
-            cb(err, results);
-        });
+        db.updateOnePullArray(COLLECTION, id, "likes", obj, cb);
     };
 
     module.update = function(id, property, value, cb) {

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -47,6 +47,14 @@ module.exports = function(db) {
         db.updateOnePullArray(COLLECTION, id, "likes", obj, cb);
     };
 
+    module.back = function(id, backObj, cb) {
+        db.updateOnePushArray(COLLECTION, id, "backs", backObj, cb);
+    };
+
+    module.unback = function(id, userId, cb) {
+        db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
+    };
+
     module.update = function(id, property, value, cb) {
         var updateObj = {};
         updateObj[property] = value;

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -40,28 +40,22 @@ module.exports = function(db) {
         db.updateOnePushArray(COLLECTION, id, interactionType, interactionObject, cb);
     };
 
-    module.unlike = function(id, userId, cb) {
-        var objId = new ObjectId(userId);
+    module.removeInteraction = function(id, interactionType, interactionObject, cb) {
+        if (typeof interactionObject.userId !== "undefined") {
+            interactionObject.userId = new ObjectId(interactionObject.userId);
+        }
 
-        var obj = {
-            userId: objId
-        };
+        if (typeof interactionObject.authorId !== "undefined") {
+            interactionObject.authorId = new ObjectId(interactionObject.authorId);
+        }
 
-        db.updateOnePullArray(COLLECTION, id, "likes", obj, cb);
-    };
-
-    module.unback = function(id, backObj, cb) {
-        db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
+        db.updateOnePullArray(COLLECTION, id, interactionType, interactionObject, cb);
     };
 
     module.editBack = function(id, authorId, newBack, cb) {
         var objId = new ObjectId(authorId);
         newBack.authorId = new ObjectId(newBack.authorId);
         db.updateOneArrayElement(COLLECTION, id, "backs", "authorId", objId, newBack, cb);
-    };
-
-    module.deleteUpdate = function(id, updateObj, cb) {
-        db.updateOnePullArray(COLLECTION, id, "updates", updateObj, cb);
     };
 
     module.update = function(id, property, value, cb) {
@@ -203,7 +197,7 @@ module.exports = function(db) {
         if (!isEmittingUpdates) {
             isEmittingUpdates = true;
             setTimeout(function() {
-                ideaProto.emit("updateIdea_" + key, idea);
+                ideaProto.emit("updateIdea_" + key, newestIdea);
                 isEmittingUpdates = false;
             }, 500);
         }

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -55,6 +55,12 @@ module.exports = function(db) {
         db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
     };
 
+    module.editBack = function(id, authorId, newBack, cb) {
+        var objId = new ObjectId(authorId);
+        newBack.authorId = new ObjectId(newBack.authorId);
+        db.updateOneArrayElement(COLLECTION, id, "backs", "authorId", objId, newBack, cb);
+    };
+
     module.postUpdate = function(id, updateObj, cb) {
         db.updateOnePushArray(COLLECTION, id, "updates", updateObj, cb);
     };

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -55,6 +55,14 @@ module.exports = function(db) {
         db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
     };
 
+    module.postUpdate = function(id, updateObj, cb) {
+        db.updateOnePushArray(COLLECTION, id, "updates", updateObj, cb);
+    };
+
+    module.deleteUpdate = function(id, updateObj, cb) {
+        db.updateOnePullArray(COLLECTION, id, "updates", updateObj, cb);
+    };
+
     module.update = function(id, property, value, cb) {
         var updateObj = {};
         updateObj[property] = value;

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -28,6 +28,25 @@ module.exports = function(db) {
         });
     };
 
+    module.like = function(id, userId, cb) {
+        var obj = {
+            userId: userId
+        };
+        db.updateOnePushArray(COLLECTION, id, "likes", obj, cb);
+    };
+
+    module.unlike = function(id, userId, cb) {
+        var objId = new ObjectId(userId);
+
+        var obj = {
+            userId: objId
+        };
+
+        db.findAndPullArray(COLLECTION, "likes", obj, function(err, results) {
+            cb(err, results);
+        });
+    };
+
     module.update = function(id, property, value, cb) {
         var updateObj = {};
         updateObj[property] = value;

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -28,13 +28,16 @@ module.exports = function(db) {
         });
     };
 
-    module.like = function(id, userId, cb) {
-        var objId = new ObjectId(userId);
+    module.addInteraction = function(id, interactionType, interactionObject, cb) {
+        if (typeof interactionObject.userId !== "undefined") {
+            interactionObject.userId = new ObjectId(interactionObject.userId);
+        }
 
-        var obj = {
-            userId: objId
-        };
-        db.updateOnePushArray(COLLECTION, id, "likes", obj, cb);
+        if (typeof interactionObject.authorId !== "undefined") {
+            interactionObject.authorId = new ObjectId(interactionObject.authorId);
+        }
+
+        db.updateOnePushArray(COLLECTION, id, interactionType, interactionObject, cb);
     };
 
     module.unlike = function(id, userId, cb) {
@@ -47,10 +50,6 @@ module.exports = function(db) {
         db.updateOnePullArray(COLLECTION, id, "likes", obj, cb);
     };
 
-    module.back = function(id, backObj, cb) {
-        db.updateOnePushArray(COLLECTION, id, "backs", backObj, cb);
-    };
-
     module.unback = function(id, backObj, cb) {
         db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
     };
@@ -59,10 +58,6 @@ module.exports = function(db) {
         var objId = new ObjectId(authorId);
         newBack.authorId = new ObjectId(newBack.authorId);
         db.updateOneArrayElement(COLLECTION, id, "backs", "authorId", objId, newBack, cb);
-    };
-
-    module.postUpdate = function(id, updateObj, cb) {
-        db.updateOnePushArray(COLLECTION, id, "updates", updateObj, cb);
     };
 
     module.deleteUpdate = function(id, updateObj, cb) {

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -51,7 +51,7 @@ module.exports = function(db) {
         db.updateOnePushArray(COLLECTION, id, "backs", backObj, cb);
     };
 
-    module.unback = function(id, userId, cb) {
+    module.unback = function(id, backObj, cb) {
         db.updateOnePullArray(COLLECTION, id, "backs", backObj, cb);
     };
 

--- a/server/routes.js
+++ b/server/routes.js
@@ -192,6 +192,38 @@ module.exports = function(app) {
             }
         });
     });
+    app.patch('/idea/back', function(req, res) {
+        ideas.back(req.body.id, req.body.backObj, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                ideas.get(req.body.id, function(err, idea) {
+                    IdeasInstance.updateIdea(idea);
+                });
+                ideas.fetch(function(err, headers) {
+                    IdeasInstance.newHeaders(headers);
+                });
+                res.sendStatus(200);
+            }
+        });
+    });
+    app.patch('/idea/unback', function(req, res) {
+        ideas.unback(req.body.id, req.body.backObj, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                ideas.get(req.body.id, function(err, idea) {
+                    IdeasInstance.updateIdea(idea);
+                });
+                ideas.fetch(function(err, headers) {
+                    IdeasInstance.newHeaders(headers);
+                });
+                res.sendStatus(200);
+            }
+        });
+    });
     app.post('/editidea', function(req, res) {
         ideas.edit(req.body.id, req.body.title, req.body.description, req.body.rolesreq, function(err) {
             if (err) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -146,26 +146,19 @@ module.exports = function(app) {
             }
         });
     });
-    app.post('/idea/like', function(req, res) {
-        ideas.like(req.body.id, req.body.userId, function(err) {
+    app.post('/idea/addinteraction', function(req, res) {
+        ideas.addInteraction(req.body.id, req.body.interactionType, req.body.interactionObject, function(err) {
             if (err) {
                 res.sendStatus(500);
             }
             else {
-                users.likeIdea(req.body.userId, req.body.id, function(err) {
-                    if (err) {
-                        res.sendStatus(500);
-                    }
-                    else {
-                        ideas.get(req.body.id, function(err, idea) {
-                            IdeasInstance.updateIdea(idea);
-                        });
-                        ideas.fetch(function(err, headers) {
-                            IdeasInstance.newHeaders(headers);
-                        });
-                        res.sendStatus(200);
-                    }
+                ideas.get(req.body.id, function(err, idea) {
+                    IdeasInstance.updateIdea(idea);
                 });
+                ideas.fetch(function(err, headers) {
+                    IdeasInstance.newHeaders(headers);
+                });
+                res.sendStatus(200);
             }
         });
     });
@@ -192,40 +185,8 @@ module.exports = function(app) {
             }
         });
     });
-    app.post('/idea/back', function(req, res) {
-        ideas.back(req.body.id, req.body.backObj, function(err) {
-            if (err) {
-                res.sendStatus(500);
-            }
-            else {
-                ideas.get(req.body.id, function(err, idea) {
-                    IdeasInstance.updateIdea(idea);
-                });
-                ideas.fetch(function(err, headers) {
-                    IdeasInstance.newHeaders(headers);
-                });
-                res.sendStatus(200);
-            }
-        });
-    });
     app.post('/idea/editback', function(req, res) {
         ideas.editBack(req.body.id, req.body.authorId, req.body.new, function(err) {
-            if (err) {
-                res.sendStatus(500);
-            }
-            else {
-                ideas.get(req.body.id, function(err, idea) {
-                    IdeasInstance.updateIdea(idea);
-                });
-                ideas.fetch(function(err, headers) {
-                    IdeasInstance.newHeaders(headers);
-                });
-                res.sendStatus(200);
-            }
-        });
-    });
-    app.post('/idea/postupdate', function(req, res) {
-        ideas.postUpdate(req.body.id, req.body.updateObj, function(err) {
             if (err) {
                 res.sendStatus(500);
             }

--- a/server/routes.js
+++ b/server/routes.js
@@ -146,6 +146,52 @@ module.exports = function(app) {
             }
         });
     });
+    app.patch('/idea/like', function(req, res) {
+        ideas.like(req.body.id, req.body.userId, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                users.likeIdea(req.body.userId, req.body.id, function(err) {
+                    if (err) {
+                        res.sendStatus(500);
+                    }
+                    else {
+                        ideas.get(req.body.id, function(err, idea) {
+                            IdeasInstance.updateIdea(idea);
+                        });
+                        ideas.fetch(function(err, headers) {
+                            IdeasInstance.newHeaders(headers);
+                        });
+                        res.sendStatus(200);
+                    }
+                });
+            }
+        });
+    });
+    app.patch('/idea/unlike', function(req, res) {
+        ideas.unlike(req.body.id, req.body.userId, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                users.unlikeIdea(req.body.userId, req.body.id, function(err) {
+                    if (err) {
+                        res.sendStatus(500);
+                    }
+                    else {
+                        ideas.get(req.body.id, function(err, idea) {
+                            IdeasInstance.updateIdea(idea);
+                        });
+                        ideas.fetch(function(err, headers) {
+                            IdeasInstance.newHeaders(headers);
+                        });
+                        res.sendStatus(200);
+                    }
+                });
+            }
+        });
+    });
     app.post('/editidea', function(req, res) {
         ideas.edit(req.body.id, req.body.title, req.body.description, req.body.rolesreq, function(err) {
             if (err) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -246,16 +246,6 @@ module.exports = function(app) {
             }
         });
     });
-    app.post('/updateaccount', function(req, res) {
-        users.update(req.body._id, "likedIdeas", req.body.likedIdeas, function(err, results) {
-            if (err || results.value === null) {
-                console.error(chalk.bgRed(err));
-            }
-            else {
-                res.sendStatus(200);
-            }
-        });
-    });
     app.get('/user', function(req, res) {
         users.get(req.query.id, function(err, responseObj) {
             if (err) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -146,7 +146,7 @@ module.exports = function(app) {
             }
         });
     });
-    app.patch('/idea/like', function(req, res) {
+    app.post('/idea/like', function(req, res) {
         ideas.like(req.body.id, req.body.userId, function(err) {
             if (err) {
                 res.sendStatus(500);
@@ -169,7 +169,7 @@ module.exports = function(app) {
             }
         });
     });
-    app.patch('/idea/unlike', function(req, res) {
+    app.post('/idea/unlike', function(req, res) {
         ideas.unlike(req.body.id, req.body.userId, function(err) {
             if (err) {
                 res.sendStatus(500);
@@ -192,7 +192,7 @@ module.exports = function(app) {
             }
         });
     });
-    app.patch('/idea/back', function(req, res) {
+    app.post('/idea/back', function(req, res) {
         ideas.back(req.body.id, req.body.backObj, function(err) {
             if (err) {
                 res.sendStatus(500);
@@ -208,8 +208,25 @@ module.exports = function(app) {
             }
         });
     });
-    app.patch('/idea/unback', function(req, res) {
-        ideas.unback(req.body.id, req.body.backObj, function(err) {
+    app.post('/idea/postupdate', function(req, res) {
+        ideas.postUpdate(req.body.id, req.body.updateObj, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                ideas.get(req.body.id, function(err, idea) {
+                    IdeasInstance.updateIdea(idea);
+                });
+                ideas.fetch(function(err, headers) {
+                    IdeasInstance.newHeaders(headers);
+                });
+                res.sendStatus(200);
+            }
+        });
+    });
+    app.post('/idea/deleteupdate', function(req, res) {
+        console.log(req.body);
+        ideas.deleteUpdate(req.body.id, req.body.updateObj, function(err) {
             if (err) {
                 res.sendStatus(500);
             }

--- a/server/routes.js
+++ b/server/routes.js
@@ -208,6 +208,22 @@ module.exports = function(app) {
             }
         });
     });
+    app.post('/idea/editback', function(req, res) {
+        ideas.editBack(req.body.id, req.body.authorId, req.body.new, function(err) {
+            if (err) {
+                res.sendStatus(500);
+            }
+            else {
+                ideas.get(req.body.id, function(err, idea) {
+                    IdeasInstance.updateIdea(idea);
+                });
+                ideas.fetch(function(err, headers) {
+                    IdeasInstance.newHeaders(headers);
+                });
+                res.sendStatus(200);
+            }
+        });
+    });
     app.post('/idea/postupdate', function(req, res) {
         ideas.postUpdate(req.body.id, req.body.updateObj, function(err) {
             if (err) {

--- a/server/routes.js
+++ b/server/routes.js
@@ -225,7 +225,6 @@ module.exports = function(app) {
         });
     });
     app.post('/idea/deleteupdate', function(req, res) {
-        console.log(req.body);
         ideas.deleteUpdate(req.body.id, req.body.updateObj, function(err) {
             if (err) {
                 res.sendStatus(500);

--- a/server/routes.js
+++ b/server/routes.js
@@ -162,31 +162,8 @@ module.exports = function(app) {
             }
         });
     });
-    app.post('/idea/unlike', function(req, res) {
-        ideas.unlike(req.body.id, req.body.userId, function(err) {
-            if (err) {
-                res.sendStatus(500);
-            }
-            else {
-                users.unlikeIdea(req.body.userId, req.body.id, function(err) {
-                    if (err) {
-                        res.sendStatus(500);
-                    }
-                    else {
-                        ideas.get(req.body.id, function(err, idea) {
-                            IdeasInstance.updateIdea(idea);
-                        });
-                        ideas.fetch(function(err, headers) {
-                            IdeasInstance.newHeaders(headers);
-                        });
-                        res.sendStatus(200);
-                    }
-                });
-            }
-        });
-    });
-    app.post('/idea/editback', function(req, res) {
-        ideas.editBack(req.body.id, req.body.authorId, req.body.new, function(err) {
+    app.post('/idea/removeinteraction', function(req, res) {
+        ideas.removeInteraction(req.body.id, req.body.interactionType, req.body.interactionObject, function(err) {
             if (err) {
                 res.sendStatus(500);
             }
@@ -201,8 +178,8 @@ module.exports = function(app) {
             }
         });
     });
-    app.post('/idea/deleteupdate', function(req, res) {
-        ideas.deleteUpdate(req.body.id, req.body.updateObj, function(err) {
+    app.post('/idea/editback', function(req, res) {
+        ideas.editBack(req.body.id, req.body.authorId, req.body.new, function(err) {
             if (err) {
                 res.sendStatus(500);
             }

--- a/server/server.js
+++ b/server/server.js
@@ -39,7 +39,7 @@ app.use(express.static(path.join(__dirname + '/../src')));
 app.use(bodyParser.json());
 
 if (process.env.NODE_ENV === 'production') {
-
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     app.use(morgan(':remote-addr - ' +
         chalk.cyan('[:date] ') +
         chalk.green('":method :url ') +
@@ -66,25 +66,19 @@ if (process.env.NODE_ENV === 'production') {
 
     passport.serializeUser(function(user, done) {
         "use strict";
-        console.log('serializeUser: ' + user.id);
-        done(null, user.id);
+        console.log('serializeUser: ' + user._json.sAMAccountName);
+        done(null, user);
     });
 
-    passport.deserializeUser(function(id, done) {
+    passport.deserializeUser(function(user, done) {
         "use strict";
-        if (id) {
-            done(null);
+        if (user) {
+            console.log('deserializeUser:' + user._json.sAMAccountName);
+            users.findForLogin(user, done);
         }
-        //TODO: Not sure what this is or why we need it, but we'll do it later.
-        // db.users.findById(id, function(err, user){
-        //     console.log(user);
-        //     if (!err) {
-        //         done(null, user);
-        //     }
-        //     else {
-        //         done(err, null);
-        //     }
-        // });
+        else {
+            done("No user provided!")
+        }
     });
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -72,12 +72,14 @@ if (process.env.NODE_ENV === 'production') {
 
     passport.deserializeUser(function(user, done) {
         "use strict";
+        var users = require('./users/users')(GLOBAL.db);
+
         if (user) {
             console.log('deserializeUser:' + user._json.sAMAccountName);
             users.findForLogin(user, done);
         }
         else {
-            done("No user provided!")
+            done("No user provided!");
         }
     });
 }

--- a/server/users/userModel.js
+++ b/server/users/userModel.js
@@ -11,7 +11,6 @@ function User(firstName, lastName, fullName, username, email, nickname, title) {
     this.email = email;
     this.nickname = nickname;
     this.title = title;
-    this.likedIdeas = [];
 
     return this;
 }
@@ -32,7 +31,6 @@ function UserLDAP(ldapObj) {
     this.email = ldapJson.mail;
     this.nickname = ldapJson.cn;
     this.title = ldapJson.title;
-    this.likedIdeas = [];
 
     return this;
 }

--- a/server/users/users.js
+++ b/server/users/users.js
@@ -35,8 +35,7 @@ module.exports = function(db) {
                     _id: user._id,
                     username: user.username,
                     email: user.email,
-                    name: user.fullName,
-                    likedIdeas: []
+                    name: user.fullName
                 };
                 cb(null, responseObj);
             }
@@ -54,8 +53,7 @@ module.exports = function(db) {
                     _id: doc._id,
                     name: doc.fullName,
                     username: doc.username,
-                    email: doc.email,
-                    likedIdeas: doc.likedIdeas
+                    email: doc.email
                 });
             }
         });
@@ -81,8 +79,7 @@ module.exports = function(db) {
                 var responseObj = {
                     name: doc.fullName,
                     mail: doc.email,
-                    username: doc.username,
-                    likedIdeas: doc.likedIdeas
+                    username: doc.username
                 };
                 cb(null, responseObj);
             }
@@ -96,14 +93,6 @@ module.exports = function(db) {
         db.updateOne(COLLECTION, id, updateObj, function(err, results) {
             cb(err, results);
         });
-    };
-
-    module.likeIdea = function likeIdea(id, ideaId, cb) {
-        db.updateOnePushArray(COLLECTION, id, "likedIdeas", ideaId, cb);
-    };
-
-    module.unlikeIdea = function unlikeIdea(id, ideaId, cb) {
-        db.updateOnePullArray(COLLECTION, id, "likedIdeas", ideaId, cb);
     };
 
     return module;

--- a/server/users/users.js
+++ b/server/users/users.js
@@ -98,5 +98,13 @@ module.exports = function(db) {
         });
     };
 
+    module.likeIdea = function likeIdea(id, ideaId, cb) {
+        db.updateOnePushArray(COLLECTION, id, "likedIdeas", ideaId, cb);
+    };
+
+    module.unlikeIdea = function unlikeIdea(id, ideaId, cb) {
+        db.findAndPullArray(COLLECTION, "likedIdeas", ideaId, cb);
+    };
+
     return module;
 };

--- a/server/users/users.js
+++ b/server/users/users.js
@@ -81,7 +81,8 @@ module.exports = function(db) {
                 var responseObj = {
                     name: doc.fullName,
                     mail: doc.email,
-                    username: doc.username
+                    username: doc.username,
+                    likedIdeas: doc.likedIdeas
                 };
                 cb(null, responseObj);
             }

--- a/server/users/users.js
+++ b/server/users/users.js
@@ -103,7 +103,7 @@ module.exports = function(db) {
     };
 
     module.unlikeIdea = function unlikeIdea(id, ideaId, cb) {
-        db.findAndPullArray(COLLECTION, "likedIdeas", ideaId, cb);
+        db.updateOnePullArray(COLLECTION, id, "likedIdeas", ideaId, cb);
     };
 
     return module;

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -61,12 +61,29 @@ angular.module('flintAndSteel')
                 }
             };
 
-            this.likeIdea = function likeIdea(ideaId, userId, successCb, errorCb) {
+            this.addInteraction = function addInteraction(ideaId, type, object, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/like',
+                    $http.post('/idea/addinteraction',
                             {
                                 id: ideaId,
-                                userId: userId
+                                interactionType: type,
+                                interactionObject: object
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
+            this.likeIdea = function likeIdea(ideaId, userId, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.post('/idea/addinteraction',
+                            {
+                                id: ideaId,
+                                interactionType: "likes",
+                                interactionObject: {
+                                    userId: userId
+                                }
                             }
                         )
                         .success(successCb)
@@ -89,10 +106,11 @@ angular.module('flintAndSteel')
 
             this.backIdea = function backIdea(ideaId, backObj, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/back',
+                    $http.post('/idea/addInteraction',
                             {
                                 id: ideaId,
-                                backObj: backObj
+                                interactionType: "backs",
+                                interactionObject: backObj
                             }
                         )
                         .success(successCb)
@@ -129,10 +147,11 @@ angular.module('flintAndSteel')
 
             this.postUpdate = function postUpdate(ideaId, updateObj, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/postupdate',
+                    $http.post('/idea/addinteraction',
                             {
                                 id: ideaId,
-                                updateObj: updateObj
+                                interactionType: "updates",
+                                interactionObject: updateObj
                             }
                         )
                         .success(successCb)
@@ -202,12 +221,10 @@ angular.module('flintAndSteel')
                 postComment: this.postComment,
                 deleteComment: this.deleteComment,
                 updateIdea: this.updateIdea,
-                likeIdea: this.likeIdea,
+                addInteraction: this.addInteraction,
                 unlikeIdea: this.unlikeIdea,
-                backIdea: this.backIdea,
                 editBack: this.editBack,
                 unbackIdea: this.unbackIdea,
-                postUpdate: this.postUpdate,
                 deleteUpdate: this.deleteUpdate,
                 editIdea: this.editIdea,
                 deleteIdea: this.deleteIdea,

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -87,6 +87,32 @@ angular.module('flintAndSteel')
                 }
             };
 
+            this.backIdea = function backIdea(ideaId, backObj, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.patch('/idea/back',
+                            {
+                                id: ideaId,
+                                backObj: backObj
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
+            this.unbackIdea = function unbackIdea(ideaId, backObj, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.patch('/idea/unback',
+                            {
+                                id: ideaId,
+                                backObj: backObj
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
             this.editIdea = function editIdea(ideaId, title, description, rolesreq, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
                     $http.post('/editidea',
@@ -139,6 +165,8 @@ angular.module('flintAndSteel')
                 updateIdea: this.updateIdea,
                 likeIdea: this.likeIdea,
                 unlikeIdea: this.unlikeIdea,
+                backIdea: this.backIdea,
+                unbackIdea: this.unbackIdea,
                 editIdea: this.editIdea,
                 deleteIdea: this.deleteIdea,
                 getBackTypeChips: this.getBackTypeChips

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -61,6 +61,32 @@ angular.module('flintAndSteel')
                 }
             };
 
+            this.likeIdea = function likeIdea(ideaId, userId, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.patch('/idea/like',
+                            {
+                                id: ideaId,
+                                userId: userId
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
+            this.unlikeIdea = function unlikeIdea(ideaId, userId, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.patch('/idea/unlike',
+                            {
+                                id: ideaId,
+                                userId: userId
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
             this.editIdea = function editIdea(ideaId, title, description, rolesreq, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
                     $http.post('/editidea',
@@ -111,6 +137,8 @@ angular.module('flintAndSteel')
                 deleteComment: this.deleteComment,
                 getUniqueId: this.getUniqueId,
                 updateIdea: this.updateIdea,
+                likeIdea: this.likeIdea,
+                unlikeIdea: this.unlikeIdea,
                 editIdea: this.editIdea,
                 deleteIdea: this.deleteIdea,
                 getBackTypeChips: this.getBackTypeChips

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -63,7 +63,7 @@ angular.module('flintAndSteel')
 
             this.likeIdea = function likeIdea(ideaId, userId, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.patch('/idea/like',
+                    $http.post('/idea/like',
                             {
                                 id: ideaId,
                                 userId: userId
@@ -76,7 +76,7 @@ angular.module('flintAndSteel')
 
             this.unlikeIdea = function unlikeIdea(ideaId, userId, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.patch('/idea/unlike',
+                    $http.post('/idea/unlike',
                             {
                                 id: ideaId,
                                 userId: userId
@@ -89,7 +89,7 @@ angular.module('flintAndSteel')
 
             this.backIdea = function backIdea(ideaId, backObj, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.patch('/idea/back',
+                    $http.post('/idea/back',
                             {
                                 id: ideaId,
                                 backObj: backObj
@@ -102,10 +102,36 @@ angular.module('flintAndSteel')
 
             this.unbackIdea = function unbackIdea(ideaId, backObj, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.patch('/idea/unback',
+                    $http.post('/idea/unback',
                             {
                                 id: ideaId,
                                 backObj: backObj
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
+            this.postUpdate = function postUpdate(ideaId, updateObj, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.post('/idea/postupdate',
+                            {
+                                id: ideaId,
+                                updateObj: updateObj
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
+            this.deleteUpdate = function deleteUpdate(ideaId, updateObj, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.post('/idea/deleteupdate',
+                            {
+                                id: ideaId,
+                                updateObj: updateObj
                             }
                         )
                         .success(successCb)
@@ -161,12 +187,13 @@ angular.module('flintAndSteel')
                 getIdeaHeaders: this.getIdeaHeaders,
                 postComment: this.postComment,
                 deleteComment: this.deleteComment,
-                getUniqueId: this.getUniqueId,
                 updateIdea: this.updateIdea,
                 likeIdea: this.likeIdea,
                 unlikeIdea: this.unlikeIdea,
                 backIdea: this.backIdea,
                 unbackIdea: this.unbackIdea,
+                postUpdate: this.postUpdate,
+                deleteUpdate: this.deleteUpdate,
                 editIdea: this.editIdea,
                 deleteIdea: this.deleteIdea,
                 getBackTypeChips: this.getBackTypeChips

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -75,42 +75,13 @@ angular.module('flintAndSteel')
                 }
             };
 
-            this.likeIdea = function likeIdea(ideaId, userId, successCb, errorCb) {
+            this.removeInteraction = function removeInteraction(ideaId, type, object, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/addinteraction',
+                    $http.post('/idea/removeinteraction',
                             {
                                 id: ideaId,
-                                interactionType: "likes",
-                                interactionObject: {
-                                    userId: userId
-                                }
-                            }
-                        )
-                        .success(successCb)
-                        .error(errorCb);
-                }
-            };
-
-            this.unlikeIdea = function unlikeIdea(ideaId, userId, successCb, errorCb) {
-                if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/unlike',
-                            {
-                                id: ideaId,
-                                userId: userId
-                            }
-                        )
-                        .success(successCb)
-                        .error(errorCb);
-                }
-            };
-
-            this.backIdea = function backIdea(ideaId, backObj, successCb, errorCb) {
-                if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/addInteraction',
-                            {
-                                id: ideaId,
-                                interactionType: "backs",
-                                interactionObject: backObj
+                                interactionType: type,
+                                interactionObject: object
                             }
                         )
                         .success(successCb)
@@ -125,46 +96,6 @@ angular.module('flintAndSteel')
                                 id: ideaId,
                                 authorId: backAuthorId,
                                 new: newBack
-                            }
-                        )
-                        .success(successCb)
-                        .error(errorCb);
-                }
-            };
-
-            this.unbackIdea = function unbackIdea(ideaId, backObj, successCb, errorCb) {
-                if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/unback',
-                            {
-                                id: ideaId,
-                                backObj: backObj
-                            }
-                        )
-                        .success(successCb)
-                        .error(errorCb);
-                }
-            };
-
-            this.postUpdate = function postUpdate(ideaId, updateObj, successCb, errorCb) {
-                if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/addinteraction',
-                            {
-                                id: ideaId,
-                                interactionType: "updates",
-                                interactionObject: updateObj
-                            }
-                        )
-                        .success(successCb)
-                        .error(errorCb);
-                }
-            };
-
-            this.deleteUpdate = function deleteUpdate(ideaId, updateObj, successCb, errorCb) {
-                if (ideaId !== 'mock_idea') {
-                    $http.post('/idea/deleteupdate',
-                            {
-                                id: ideaId,
-                                updateObj: updateObj
                             }
                         )
                         .success(successCb)
@@ -222,10 +153,8 @@ angular.module('flintAndSteel')
                 deleteComment: this.deleteComment,
                 updateIdea: this.updateIdea,
                 addInteraction: this.addInteraction,
-                unlikeIdea: this.unlikeIdea,
+                removeInteraction: this.removeInteraction,
                 editBack: this.editBack,
-                unbackIdea: this.unbackIdea,
-                deleteUpdate: this.deleteUpdate,
                 editIdea: this.editIdea,
                 deleteIdea: this.deleteIdea,
                 getBackTypeChips: this.getBackTypeChips

--- a/src/ideas/ideaSvc/ideaSvc.js
+++ b/src/ideas/ideaSvc/ideaSvc.js
@@ -100,6 +100,20 @@ angular.module('flintAndSteel')
                 }
             };
 
+            this.editBack = function editBack(ideaId, backAuthorId, newBack, successCb, errorCb) {
+                if (ideaId !== 'mock_idea') {
+                    $http.post('/idea/editback',
+                            {
+                                id: ideaId,
+                                authorId: backAuthorId,
+                                new: newBack
+                            }
+                        )
+                        .success(successCb)
+                        .error(errorCb);
+                }
+            };
+
             this.unbackIdea = function unbackIdea(ideaId, backObj, successCb, errorCb) {
                 if (ideaId !== 'mock_idea') {
                     $http.post('/idea/unback',
@@ -191,6 +205,7 @@ angular.module('flintAndSteel')
                 likeIdea: this.likeIdea,
                 unlikeIdea: this.unlikeIdea,
                 backIdea: this.backIdea,
+                editBack: this.editBack,
                 unbackIdea: this.unbackIdea,
                 postUpdate: this.postUpdate,
                 deleteUpdate: this.deleteUpdate,

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -155,6 +155,14 @@ angular.module('flintAndSteel')
                     mockIdea[property] = data;
                     successCb('OK');
                 },
+                likeIdea: function likeIdea(ideaId, userId, successCb) {
+                    mockIdea.likes.push({userId: userId});
+                    successCb('OK');
+                },
+                unlikeIdea: function unlikeIdea(ideaId, userId, successCb) {
+                    mockIdea.likes.splice(mockIdea.likes.indexOf({userId: userId}), 1);
+                    successCb('OK');
+                },
                 editIdea: function editIdea(ideaId, title, description, rolesreq, successCb) {
                     mockIdea.title = title;
                     mockIdea.description = description;

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -155,6 +155,14 @@ angular.module('flintAndSteel')
                     mockIdea.backs.splice(mockIdea.backs.indexOf(backObj), 1);
                     successCb('OK');
                 },
+                postUpdate: function postUpdate(ideaId, updateObj, successCb) {
+                    mockIdea.updates.push(updateObj);
+                    successCb('OK');
+                },
+                deleteUpdate: function deleteUpdate(ideaId, updateObj, successCb) {
+                    mockIdea.updates.splice(mockIdea.updates.indexOf(updateObj), 1);
+                    successCb('OK');
+                },
                 editIdea: function editIdea(ideaId, title, description, rolesreq, successCb) {
                     mockIdea.title = title;
                     mockIdea.description = description;

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -139,16 +139,12 @@ angular.module('flintAndSteel')
                     mockIdea[property] = data;
                     successCb('OK');
                 },
-                likeIdea: function likeIdea(ideaId, userId, successCb) {
-                    mockIdea.likes.push({userId: userId});
+                addInteraction: function addInteraction(ideaId, type, object, successCb) {
+                    mockIdea[type].push(object);
                     successCb('OK');
                 },
-                unlikeIdea: function unlikeIdea(ideaId, userId, successCb) {
-                    mockIdea.likes.splice(mockIdea.likes.indexOf({userId: userId}), 1);
-                    successCb('OK');
-                },
-                backIdea: function backIdea(ideaId, backObj, successCb) {
-                    mockIdea.backs.push(backObj);
+                removeInteraction: function removeInteraction(ideaId, type, object, successCb) {
+                    mockIdea[type].splice(mockIdea[type].indexOf(object), 1);
                     successCb('OK');
                 },
                 editBack: function editBack(ideaId, backAuthorId, newBack, successCb) {
@@ -158,18 +154,6 @@ angular.module('flintAndSteel')
                             successCb('OK');
                         }
                     }
-                },
-                unbackIdea: function unbackIdea(ideaId, backObj, successCb) {
-                    mockIdea.backs.splice(mockIdea.backs.indexOf(backObj), 1);
-                    successCb('OK');
-                },
-                postUpdate: function postUpdate(ideaId, updateObj, successCb) {
-                    mockIdea.updates.push(updateObj);
-                    successCb('OK');
-                },
-                deleteUpdate: function deleteUpdate(ideaId, updateObj, successCb) {
-                    mockIdea.updates.splice(mockIdea.updates.indexOf(updateObj), 1);
-                    successCb('OK');
                 },
                 editIdea: function editIdea(ideaId, title, description, rolesreq, successCb) {
                     mockIdea.title = title;

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -23,21 +23,13 @@ angular.module('flintAndSteel')
                 authorId: 1,
                 image: '../assets/defaultideahero.jpg',
                 likes: [
-                    'cottageclaw',
-                    'vbfond',
-                    'curvechange',
-                    'bothdesigned',
-                    'gymnastfinance',
-                    'aberrantcollagen',
-                    'kuwaitiinspiring',
-                    'basteglyderau',
-                    'adoptionpanting',
-                    'tokenslagoon',
-                    'welshwood',
-                    'kumquatslant',
-                    'anaerobedigits',
-                    'chouxthames',
-                    'pizzago'
+                    {userId: 1},
+                    {userId: 2},
+                    {userId: 3},
+                    {userId: 4},
+                    {userId: 5},
+                    {userId: 6},
+                    {userId: 7}
                 ],
                 managerLikes: 6,
                 comments: [

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -151,6 +151,14 @@ angular.module('flintAndSteel')
                     mockIdea.backs.push(backObj);
                     successCb('OK');
                 },
+                editBack: function editBack(ideaId, backAuthorId, newBack, successCb) {
+                    for (var i = 0; i < mockIdea.backs.length; i++) {
+                        if (mockIdea.backs[i].authorId === backAuthorId) {
+                            mockIdea.backs.splice(i, 1, newBack);
+                            successCb('OK');
+                        }
+                    }
+                },
                 unbackIdea: function unbackIdea(ideaId, backObj, successCb) {
                     mockIdea.backs.splice(mockIdea.backs.indexOf(backObj), 1);
                     successCb('OK');

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -151,9 +151,6 @@ angular.module('flintAndSteel')
                     }
                     successCb('Deleted');
                 },
-                getUniqueId: function getUniqueId() {
-                    throw new NotImplementedException('getUniqueId');
-                },
                 updateIdea: function updateIdea(ideaId, property, data, successCb) {
                     mockIdea[property] = data;
                     successCb('OK');
@@ -179,7 +176,7 @@ angular.module('flintAndSteel')
                         { name: 'Test Chip'}
                     ];
                     return types.map(function(type) {
-                        type._lowername = type.name.toLowerCase();
+                        type._lowername = type.name.toLowerCase().replace(/[ ]/g, '-').replace('?', '');
                         return type;
                     });
                 }

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -96,14 +96,6 @@ angular.module('flintAndSteel')
                 ]
             };
 
-            function NotImplementedException(call) {
-                this.name = 'NotImplementedException';
-                this.message = 'Method ' + call + ' has not been implemented!';
-                this.toString = function() {
-                    return this.name + ': ' + this.message;
-                };
-            }
-
             return {
                 postIdea: function postIdea(idea, successCb) {
                     successCb('Created');

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -147,6 +147,14 @@ angular.module('flintAndSteel')
                     mockIdea.likes.splice(mockIdea.likes.indexOf({userId: userId}), 1);
                     successCb('OK');
                 },
+                backIdea: function backIdea(ideaId, backObj, successCb) {
+                    mockIdea.backs.push(backObj);
+                    successCb('OK');
+                },
+                unbackIdea: function unbackIdea(ideaId, backObj, successCb) {
+                    mockIdea.backs.splice(mockIdea.backs.indexOf(backObj), 1);
+                    successCb('OK');
+                },
                 editIdea: function editIdea(ideaId, title, description, rolesreq, successCb) {
                     mockIdea.title = title;
                     mockIdea.description = description;

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -200,9 +200,8 @@ angular.module('flintAndSteel')
             };
 
             $scope.isUserLiked = function isUserLiked() {
-                var likedIdeas = loginSvc.getLikedIdeas();
-                console.log(likedIdeas);
-                return (_.findIndex(likedIdeas, function(item) { return item === $scope.idea._id; }) !== -1);
+                var userId = loginSvc.getProperty('_id');
+                return (_.findIndex($scope.idea.likes, function(like) { return like.userId === userId;}) !== -1);
             };
 
             $scope.querySearch = function querySearch(query) {

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -415,18 +415,24 @@ angular.module('flintAndSteel')
             ctrl.editBack = function editBack(backIndex) {
                 if (ctrl.isUserAuthorOfBack(backIndex)) {
                     var now = new Date().toISOString();
-                    $scope.idea.backs[backIndex].text = ctrl.editBackText;
-                    $scope.idea.backs[backIndex].types = $scope.selectedTypes;
-                    $scope.idea.backs[backIndex].timeModified = now;
-                    ideaSvc.updateIdea($scope.idea._id, 'backs', $scope.idea.backs,
-                    function success() {},
-                    function error(data, status) {
-                        console.log(status);
-                    });
+                    var newBack = {
+                        text: ctrl.editBackText,
+                        authorId: $scope.idea.backs[backIndex].authorId,
+                        time: $scope.idea.backs[backIndex].time,
+                        timeModified: now,
+                        types: $scope.selectedTypes
+                    };
+                    ideaSvc.editBack($scope.idea._id, $scope.idea.backs[backIndex].authorId, newBack,
+                        function success() {
+                            ctrl.refreshIdea();
+                        },
+                        function error(data, status) {
+                            console.log(status);
+                        }
+                    );
                     $scope.showEditBackInput = false;
                     ctrl.editBackText = '';
                     $scope.selectedTypes = [];
-                    ctrl.refreshIdea();
                 }
             };
 

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -128,19 +128,12 @@ angular.module('flintAndSteel')
                         );
                     }
                     else if (type === 'backs') {
-                        $scope.idea[type].push({
+                        $scope.backIdea({
                             text: ctrl.newBack,
                             authorId: loginSvc.getProperty('_id'),
                             time: now,
                             types: $scope.selectedTypes
                         });
-
-                        ideaSvc.updateIdea($scope.idea._id, type, $scope.idea[type],
-                            function success() { },
-                            function error(data, status) {
-                                console.log(status);
-                            }
-                        );
                     }
                     else if (type === 'updates') {
                         $scope.idea[type].push({
@@ -190,6 +183,28 @@ angular.module('flintAndSteel')
 
             $scope.unlikeIdea = function unlikeIdea() {
                 ideaSvc.unlikeIdea($scope.idea._id, loginSvc.getProperty('_id'),
+                    function success() {
+                        ctrl.refreshIdea();
+                    },
+                    function error(data, status) {
+                        console.log(status);
+                    }
+                );
+            };
+
+            $scope.backIdea = function backIdea(backObj) {
+                ideaSvc.backIdea($scope.idea._id, backObj,
+                    function success() {
+                        ctrl.refreshIdea();
+                    },
+                    function error(data, status) {
+                        console.log(status);
+                    }
+                );
+            };
+
+            $scope.unbackIdea = function unbackIdea(backObj) {
+                ideaSvc.unbackIdea($scope.idea._id, backObj,
                     function success() {
                         ctrl.refreshIdea();
                     },

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -178,32 +178,30 @@ angular.module('flintAndSteel')
             };
 
             $scope.likeIdea = function likeIdea() {
-                $scope.idea.likes.push({userId: loginSvc.getProperty('_id')});
-                ideaSvc.updateIdea($scope.idea._id, 'likes', $scope.idea.likes,
-                    function success() { },
+                ideaSvc.likeIdea($scope.idea._id, loginSvc.getProperty('_id'),
+                    function success() {
+                        ctrl.refreshIdea();
+                    },
                     function error(data, status) {
                         console.log(status);
-                    });
-                loginSvc.likeIdea($scope.idea._id);
-                ctrl.refreshIdea();
+                    }
+                );
             };
 
             $scope.unlikeIdea = function unlikeIdea() {
-                _.remove($scope.idea.likes, function(n) {
-                    return n.userId === loginSvc.getProperty('_id');
-                });
-                ideaSvc.updateIdea($scope.idea._id, 'likes', $scope.idea.likes,
-                    function success() { },
+                ideaSvc.unlikeIdea($scope.idea._id, loginSvc.getProperty('_id'),
+                    function success() {
+                        ctrl.refreshIdea();
+                    },
                     function error(data, status) {
                         console.log(status);
-                    });
-                loginSvc.unlikeIdea($scope.idea._id);
-                ctrl.refreshIdea();
+                    }
+                );
             };
 
             $scope.isUserLiked = function isUserLiked() {
-                var likedIdeas = loginSvc.getProperty('likedIdeas');
-                //console.log(likedIdeas);
+                var likedIdeas = loginSvc.getLikedIdeas();
+                console.log(likedIdeas);
                 return (_.findIndex(likedIdeas, function(item) { return item === $scope.idea._id; }) !== -1);
             };
 
@@ -339,7 +337,7 @@ angular.module('flintAndSteel')
                 }
                 return false;
             };
-            
+
             ctrl.isUserExactMemberOfTeam = function(teamIndex) {
                 if (angular.isDefined($scope.idea.team) && loginSvc.isUserLoggedIn()) {
                     if (loginSvc.getProperty('_id') === $scope.idea.team[teamIndex].memberId) {
@@ -348,13 +346,13 @@ angular.module('flintAndSteel')
                 }
                 return false;
             };
-            
+
             ctrl.removeUserFromTeam = function(backOfTeamMember) {
                 backOfTeamMember.isInTeam = false;
-                
+
                 ctrl.updateTeam();
             };
-            
+
             ctrl.isUserAuthorOfComment = function(commentIndex) {
                 if (loginSvc.isUserLoggedIn() && loginSvc.getProperty('_id') === $scope.idea.comments[commentIndex].authorId) {
                     return true;
@@ -397,13 +395,13 @@ angular.module('flintAndSteel')
                     function success() {},
                     function error(data, status) {
                         console.log(status);
-                    });               
+                    });
                     $scope.showEditBackInput = false;
-                    ctrl.editBackText = '';                    
+                    ctrl.editBackText = '';
                     $scope.selectedTypes = [];
                     ctrl.refreshIdea();
                 }
-            };            
+            };
 
             $scope.hasUserBacked = function() {
                 var hasUserBacked = false;
@@ -411,7 +409,7 @@ angular.module('flintAndSteel')
                     $scope.idea.backs.forEach(function(back) {
                         if (loginSvc.getProperty('_id') === back.authorId) {
                             hasUserBacked = true;
-                        }                        
+                        }
                     });
                 }
                 return hasUserBacked;

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -202,7 +202,7 @@ angular.module('flintAndSteel')
             };
 
             $scope.unbackIdea = function unbackIdea(index) {
-                if (isUserAuthorOfBack(index)) {
+                if (ctrl.isUserAuthorOfBack(index)) {
                     var backObj = angular.copy($scope.idea.backs[index]);
                     delete backObj.author; // author object is not stored in database
                     ideaSvc.unbackIdea($scope.idea._id, backObj,

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -118,8 +118,21 @@ angular.module('flintAndSteel')
 
             $scope.addNewInteraction = function addNewInteraction(type) {
                 var now = new Date().toISOString();
-                if (type === 'comments' || type === 'backs' || type === 'updates') {
-                    if (type === 'comments') {
+                if (type === 'likes' || type === 'comments' || type === 'backs' || type === 'updates') {
+                    if (type === 'likes') {
+                        var likeObj = {
+                            userId: loginSvc.getProperty('_id')
+                        };
+                        ideaSvc.addInteraction($scope.idea._id, type, likeObj,
+                            function success() {
+                                ctrl.refreshIdea();
+                            },
+                            function error(data, status) {
+                                console.log(status);
+                            }
+                        );
+                    }
+                    else if (type === 'comments') {
                         ideaSvc.postComment($scope.idea._id, ctrl.newComment, loginSvc.getProperty('_id'),
                             function success() {
                                 ctrl.refreshIdea();
@@ -130,19 +143,37 @@ angular.module('flintAndSteel')
                         );
                     }
                     else if (type === 'backs') {
-                        $scope.backIdea({
+                        var backObj = {
                             text: ctrl.newBack,
                             authorId: loginSvc.getProperty('_id'),
                             time: now,
                             types: $scope.selectedTypes
-                        });
+                        };
+
+                        ideaSvc.addInteraction($scope.idea._id, type, backObj,
+                            function success() {
+                                ctrl.refreshIdea();
+                            },
+                            function error(data, status) {
+                                console.log(status);
+                            }
+                        );
                     }
                     else if (type === 'updates') {
-                        $scope.postUpdate({
+                        var updateObj = {
                             text: ctrl.newUpdate,
                             authorId: loginSvc.getProperty('_id'),
                             time: now
-                        });
+                        };
+
+                        ideaSvc.addInteraction($scope.idea._id, type, updateObj,
+                            function success() {
+                                ctrl.refreshIdea();
+                            },
+                            function error(data, status) {
+                                console.log(status);
+                            }
+                        );
                     }
 
                     $scope.selectedTypes = [];
@@ -168,30 +199,8 @@ angular.module('flintAndSteel')
                 }
             };
 
-            $scope.likeIdea = function likeIdea() {
-                ideaSvc.likeIdea($scope.idea._id, loginSvc.getProperty('_id'),
-                    function success() {
-                        ctrl.refreshIdea();
-                    },
-                    function error(data, status) {
-                        console.log(status);
-                    }
-                );
-            };
-
             $scope.unlikeIdea = function unlikeIdea() {
                 ideaSvc.unlikeIdea($scope.idea._id, loginSvc.getProperty('_id'),
-                    function success() {
-                        ctrl.refreshIdea();
-                    },
-                    function error(data, status) {
-                        console.log(status);
-                    }
-                );
-            };
-
-            $scope.backIdea = function backIdea(backObj) {
-                ideaSvc.backIdea($scope.idea._id, backObj,
                     function success() {
                         ctrl.refreshIdea();
                     },
@@ -214,17 +223,6 @@ angular.module('flintAndSteel')
                         }
                     );
                 }
-            };
-
-            $scope.postUpdate = function postUpdate(updateObj) {
-                ideaSvc.postUpdate($scope.idea._id, updateObj,
-                    function success() {
-                        ctrl.refreshIdea();
-                    },
-                    function error(data, status) {
-                        console.log(status);
-                    }
-                );
             };
 
             $scope.isUserLiked = function isUserLiked() {

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -11,6 +11,18 @@ describe('IdeasViewCtrl', function() {
 
     var scope, ctrl, $stateParams, $mdDialog, ideaSvcMock, loginSvcMock, $state, toastSvc;
 
+    var authorAccount = {
+        id: 1,
+        username: 'MainManDarth',
+        name: 'Darth Vader'
+    };
+
+    var nonAuthorAccount = {
+        id: 2,
+        username: 'SonOfDarth',
+        name: 'Luke Skywalker'
+    };
+
     beforeEach(module('flintAndSteel'));
 
     beforeEach(inject(function($rootScope, $controller, _$stateParams_, _$mdDialog_, _ideaSvcMock_, _loginSvcMock_, _$state_, _toastSvc_) {
@@ -97,13 +109,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('$scope.removeInteraction()', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
         var ideaLikes, commentsLength, backsLength, updatesLength;
 
         beforeEach(function() {
@@ -219,19 +224,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('editing the idea', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
-        var nonAuthorAccount = {
-            id: 2,
-            username: 'SonOfDarth',
-            name: 'Luke Skywalker',
-            likedIdeas: [ 'mock_idea' ]
-        };
         var mockIdea;
 
         beforeEach(function() {
@@ -303,19 +295,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('deleting the idea', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
-        var nonAuthorAccount = {
-            id: 2,
-            username: 'SonOfDarth',
-            name: 'Luke Skywalker',
-            likedIdeas: [ 'mock_idea' ]
-        };
         var mockIdea;
 
         beforeEach(function() {
@@ -341,20 +320,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('deleting a comment', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
-        var nonAuthorAccount = {
-            id: 2,
-            username: 'SonOfDarth',
-            name: 'Luke Skywalker',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
         var commentIndex = 0;
         var originalLength = 0;
 
@@ -384,20 +349,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('deleting an update', function() {
-        var authorAccount = {
-            id: 7,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
-        var nonAuthorAccount = {
-            id: 2,
-            username: 'SonOfDarth',
-            name: 'Luke Skywalker',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
         var updateIndex = 0;
         var originalLength = 0;
         var mockIdea;
@@ -429,19 +380,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('editing a back', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
-        var nonAuthorAccount = {
-            id: 2,
-            username: 'SonOfDarth',
-            name: 'Luke Skywalker',
-            likedIdeas: [ 'mock_idea' ]
-        };
         var backIndex = 0;
 
         beforeEach(function() {
@@ -468,13 +406,6 @@ describe('IdeasViewCtrl', function() {
     });
 
     describe('forming a team', function() {
-        var authorAccount = {
-            id: 1,
-            username: 'MainManDarth',
-            name: 'Darth Vader',
-            likedIdeas: [ 'mock_idea' ]
-        };
-
         var teamLength = 0;
         var mockIdea;
 

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -122,7 +122,7 @@ describe('IdeasViewCtrl', function() {
     describe('$scope.isUserLiked()', function() {
 
         beforeEach(function() {
-            scope.idea._id = 'mock_idea';
+            scope.idea.likes = [{userId: 1}];
         });
 
         it('should return true for a liked idea', function() {
@@ -130,7 +130,7 @@ describe('IdeasViewCtrl', function() {
         });
 
         it('should return false for other ideas', function() {
-            scope.idea._id = 'not_mock_idea';
+            scope.idea.likes = [{userId: 2}];
             expect(scope.isUserLiked()).not.toBeTruthy();
         });
     });

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -417,7 +417,7 @@ describe('IdeasViewCtrl', function() {
         beforeEach(function() {
             ctrl.newBack = 'This is a test back!';
             scope.addNewInteraction('backs');
-            spyOn(ideaSvcMock, 'updateIdea').and.callThrough();
+            spyOn(ideaSvcMock, 'editBack').and.callThrough();
             backIndex = scope.idea.backs.length - 1;
         });
 
@@ -426,14 +426,14 @@ describe('IdeasViewCtrl', function() {
             expect(loginSvcMock.isUserLoggedIn()).toBe(true);
             ctrl.editBackText = "This back was edited!";
             ctrl.editBack(backIndex);
-            expect(ideaSvcMock.updateIdea).toHaveBeenCalled();
+            expect(ideaSvcMock.editBack).toHaveBeenCalled();
             expect(scope.idea.backs[backIndex].text).toBe("This back was edited!");
         });
 
         it('should not allow someone other than the author to edit the back', function() {
             loginSvcMock.checkLogin(nonAuthorAccount);
             ctrl.editBack(backIndex);
-            expect(ideaSvcMock.updateIdea).not.toHaveBeenCalled();
+            expect(ideaSvcMock.editBack).not.toHaveBeenCalled();
         });
     });
 

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -95,16 +95,12 @@ describe('IdeasViewCtrl', function() {
 
         beforeEach(function() {
             ideaLikes = scope.idea.likes.length;
-
-            spyOn(loginSvcMock, 'likeIdea').and.callFake(function() {
-            });
         });
 
         it('should like an idea', function() {
             scope.likeIdea();
 
             expect(scope.idea.likes.length).toBe(ideaLikes + 1);
-            expect(loginSvcMock.likeIdea).toHaveBeenCalledWith(scope.idea._id);
         });
     });
 
@@ -112,11 +108,6 @@ describe('IdeasViewCtrl', function() {
         var ideaLikes;
 
         beforeEach(function() {
-            spyOn(loginSvcMock, 'likeIdea').and.callFake(function() {
-            });
-            spyOn(loginSvcMock, 'unlikeIdea').and.callFake(function() {
-            });
-
             scope.likeIdea();
             ideaLikes = scope.idea.likes.length;
         });
@@ -125,7 +116,6 @@ describe('IdeasViewCtrl', function() {
             scope.unlikeIdea();
 
             expect(scope.idea.likes.length).toBe(ideaLikes - 1);
-            expect(loginSvcMock.unlikeIdea).toHaveBeenCalledWith(scope.idea._id);
         });
     });
 
@@ -455,7 +445,7 @@ describe('IdeasViewCtrl', function() {
             name: 'Darth Vader',
             likedIdeas: [ 'mock_idea' ]
         };
-        
+
         var teamLength = 0;
         var mockIdea;
 
@@ -516,7 +506,7 @@ describe('IdeasViewCtrl', function() {
 
             expect(scope.idea.backs[teamLength].isInTeam).toBe(false);
         });
-        
+
         it('Should return the correct user highlighted', function() {
             // Track the number of backs
             var backLength = scope.idea.backs.length;
@@ -527,39 +517,39 @@ describe('IdeasViewCtrl', function() {
             scope.idea.backs[backLength].isInTeam = true;
             ctrl.updateTeam();
             expect(scope.idea.backs[backLength].isInTeam).toBe(true);
-            
+
             // Up the back length
             backLength++;
             // Variable to reference a member in the team
             var index = 0;
             //pass in index and verify it is the user we want
             expect(ctrl.isUserExactMemberOfTeam(index)).toBe(true);
-            
+
             // Increment index
             index++;
             ctrl.newBack = 'Rick backs this idea!';
             scope.addNewInteraction('backs');
             scope.idea.backs[backLength].authorId = 2;
             scope.idea.backs[backLength].isInTeam = true;
-            
+
             backLength++;
-            
+
             ctrl.updateTeam();
             //pass in a second index and verify it is not our user
             expect(ctrl.isUserExactMemberOfTeam(index)).toBe(false);
         });
-        
-        it('Should remove the backer from the team', function() {            
+
+        it('Should remove the backer from the team', function() {
             ctrl.newBack = 'Rick backs this idea!';
             scope.addNewInteraction('backs');
             scope.idea.backs[teamLength].isInTeam = true;
             ctrl.updateTeam();
-            
+
             // Should be one member on the team
             expect(scope.idea.team.length).toBe(1);
-            
+
             // Remove user from the team and verify the team is empty
-            ctrl.removeUserFromTeam(scope.idea.backs[teamLength]);            
+            ctrl.removeUserFromTeam(scope.idea.backs[teamLength]);
             expect(scope.idea.team.length).toBe(0);
         });
     });

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -208,7 +208,6 @@ describe('IdeasViewCtrl', function() {
             ideaSvcMock.getIdea(null, function(idea) {
                 mockIdea = idea;
             });
-            spyOn(ideaSvcMock, 'updateIdea').and.callThrough();
             spyOn(ideaSvcMock, 'editIdea').and.callThrough();
         });
 
@@ -331,7 +330,6 @@ describe('IdeasViewCtrl', function() {
         beforeEach(function() {
             ctrl.newComment = 'This is a test comment!';
             scope.addNewInteraction('comments');
-            spyOn(ideaSvcMock, 'updateIdea').and.callThrough();
             spyOn(ideaSvcMock, 'deleteComment').and.callThrough();
             commentIndex = scope.idea.comments.length - 1;
             originalLength = scope.idea.comments.length;
@@ -348,7 +346,7 @@ describe('IdeasViewCtrl', function() {
         it('should not allow someone other than the author to delete the idea', function() {
             loginSvcMock.checkLogin(nonAuthorAccount);
             ctrl.deleteComment(commentIndex);
-            expect(ideaSvcMock.updateIdea).not.toHaveBeenCalled();
+            expect(ideaSvcMock.deleteComment).not.toHaveBeenCalled();
             expect(scope.idea.comments.length).toBe(originalLength);
             expect(scope.idea.comments[commentIndex].deleted).not.toBe(true);
         });
@@ -376,7 +374,8 @@ describe('IdeasViewCtrl', function() {
         beforeEach(function() {
             ctrl.newUpdate = 'This is a test update!';
             scope.addNewInteraction('updates');
-            spyOn(ideaSvcMock, 'updateIdea').and.callThrough();
+            spyOn(ideaSvcMock, 'postUpdate').and.callThrough();
+            spyOn(ideaSvcMock, 'deleteUpdate').and.callThrough();
             ideaSvcMock.getIdea(null, function(idea) {
                 mockIdea = idea;
             });
@@ -387,14 +386,14 @@ describe('IdeasViewCtrl', function() {
         it('should allow the author to delete it', function() {
             loginSvcMock.checkLogin(authorAccount);
             scope.deleteUpdate(updateIndex);
-            expect(ideaSvcMock.updateIdea).toHaveBeenCalled();
+            expect(ideaSvcMock.deleteUpdate).toHaveBeenCalled();
             expect(scope.idea.updates.length).toBe(updateIndex);
         });
 
         it('should not allow someone other than the author to delete the idea', function() {
             loginSvcMock.checkLogin(nonAuthorAccount);
             scope.deleteUpdate(updateIndex);
-            expect(ideaSvcMock.updateIdea).not.toHaveBeenCalled();
+            expect(ideaSvcMock.deleteUpdate).not.toHaveBeenCalled();
             expect(scope.idea.updates.length).toBe(originalLength);
         });
     });

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -57,7 +57,7 @@
             </md-button>
         </span>
         <span flex ng-if="isUserLoggedIn() && isUserLiked()">
-            <md-button class="md-icon-button" aria-label="Unlike" ng-click="unlikeIdea()">
+            <md-button class="md-icon-button" aria-label="Unlike" ng-click="removeInteraction('likes')">
                 <i class="material-icons icon-button-adjust">&#xE87D;</i>
             </md-button>
         </span>
@@ -90,12 +90,12 @@
                     </md-card>
                     <md-list>
                         <md-list-item class="md-2-line" ng-repeat="update in idea.updates | orderBy: 'time'" ng-show="idea.updates" ng-mouseover="hoverUpdate = true" ng-mouseout="hoverUpdate = false">
-                            <div ng-show="(ideasView.isUserAuthorOfUpdate($index) || ideasView.isUserAuthor()) && update.deleted !== true && hoverUpdate === true">
-                                <md-button class="md-icon-button" aria-label="Delete Update" ng-click= "deleteUpdate($index)">
+                            <div ng-show="(ideasView.isUserAuthorOfInteraction(update) || ideasView.isUserAuthor()) && hoverUpdate === true">
+                                <md-button class="md-icon-button" aria-label="Delete Update" ng-click= "removeInteraction('updates', update)">
                                     <i class="material-icons icon-button-adjust">&#xE14C;</i>
                                 </md-button>
                             </div>
-                            <div class="md-list-item-text" ng-class="{'deleted': update.deleted === true}">
+                            <div class="md-list-item-text">
                                 <h3>{{update.text}}</h3>
                                 <p><email-link author-obj="update.author"></email-link><small class="extra-space-left" ng-bind="momentizeTime(update.time)"></small></p>
                             </div>
@@ -124,12 +124,12 @@
                     </md-card>
                     <md-list>
                         <md-list-item class="md-2-line" ng-repeat="comment in idea.comments" ng-mouseover="hovered = true" ng-mouseout="hovered = false">
-                            <div ng-show="hovered === true && ideasView.isUserAuthorOfComment($index) && comment.deleted !== true">
-                                <md-button class="md-icon-button" aria-label="Delete Comment" ng-click="ideasView.deleteComment($index)">
+                            <div ng-show="hovered === true && ideasView.isUserAuthorOfInteraction(comment)">
+                                <md-button class="md-icon-button" aria-label="Delete Comment" ng-click="removeInteraction('comments', comment)">
                                     <i class="material-icons icon-button-adjust">&#xE14C;</i>
                                 </md-button>
                             </div>
-                            <div class="md-list-item-text" ng-class="{'deleted': comment.deleted === true}">
+                            <div class="md-list-item-text">
                                 <h3>{{comment.text}}</h3>
                                 <p><email-link author-obj="comment.author"></email-link><small class="extra-space-left" ng-bind="momentizeTime(comment.time)"></small></p>
                             </div>
@@ -141,8 +141,8 @@
                 <md-content class="md-padding">
                     <md-list>
                         <md-list-item class="md-3-line" ng-repeat="back in idea.backs" ng-mouseover="hovered = true" ng-mouseout="hovered = false">
-                            <div ng-show="hovered === true && ideasView.isUserAuthorOfBack($index)">
-                                <md-button class="md-icon-button" aria-label="Edit Back" ng-click="loadEditBack()">
+                            <div ng-show="hovered === true && ideasView.isUserAuthorOfInteraction(back)">
+                                <md-button class="md-icon-button" aria-label="Edit Back" ng-click="loadEditBack(back)">
                                     <i class="material-icons icon-button-adjust">&#xE3C9;</i>
                                 </md-button>
                             </div>
@@ -200,7 +200,7 @@
                             </md-button>
                         </div>
                         <div layout="column" layout-align="center end" ng-show="showEditBackInput">
-                            <md-button class="md-icon-button" aria-label="Submit" ng-disabled="ideasView.editBackText === ''" ng-click="ideasView.editBack(userBackIndex)">
+                            <md-button class="md-icon-button" aria-label="Submit" ng-disabled="ideasView.editBackText === ''" ng-click="ideasView.editBack(userBack)">
                                 <i class="material-icons icon-button-adjust">&#xE876;</i>
                             </md-button>
                         </div>

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -52,7 +52,7 @@
 <md-card>
     <md-card-content>
         <span flex ng-if="isUserLoggedIn() && !isUserLiked()">
-            <md-button class="md-icon-button" aria-label="Like" ng-click="likeIdea()">
+            <md-button class="md-icon-button" aria-label="Like" ng-click="addNewInteraction('likes')">
                 <i class="material-icons icon-button-adjust">&#xE87E;</i>
             </md-button>
         </span>
@@ -145,13 +145,13 @@
                                 <md-button class="md-icon-button" aria-label="Edit Back" ng-click="loadEditBack()">
                                     <i class="material-icons icon-button-adjust">&#xE3C9;</i>
                                 </md-button>
-                            </div>                            
+                            </div>
                             <div class="md-list-item-text">
                                 <h3>{{back.text}}
                                     <span class="extra-padding-left-sm">
                                         <small ng-show="!hasBackBeenEdited(back)" ng-bind="momentizeTime(back.time)"></small>
                                         <small ng-show="hasBackBeenEdited(back)" ng-bind="momentizeModifiedTime(back.timeModified)"></small>
-                                    </span>                                    
+                                    </span>
                                 </h3>
                                 <p>
                                     <email-link author-obj="back.author"></email-link>
@@ -174,7 +174,7 @@
                             <md-input-container ng-show="showEditBackInput" class="no-padding-bottom">
                                 <label>Edit your back...</label>
                                 <input ng-model="ideasView.editBackText" type="text"/>
-                            </md-input-container>                             
+                            </md-input-container>
                             <md-chips ng-model="selectedTypes" md-autocomplete-snap md-require-match="true" ng-show="ideasView.newBack || ideasView.editBackText">
                                 <md-autocomplete
                                     md-selected-item="selectedType"
@@ -203,7 +203,7 @@
                             <md-button class="md-icon-button" aria-label="Submit" ng-disabled="ideasView.editBackText === ''" ng-click="ideasView.editBack(userBackIndex)">
                                 <i class="material-icons icon-button-adjust">&#xE876;</i>
                             </md-button>
-                        </div>                        
+                        </div>
                     </div>
                 </md-content>
             </md-tab>

--- a/src/users/loginSvc/loginSvc.js
+++ b/src/users/loginSvc/loginSvc.js
@@ -20,21 +20,6 @@ angular.module('flintAndSteel')
                     .error(errorCb);
             };
 
-            this.addUser = function addUser(account, successCb, errorCb) {
-                //console.log(account);
-                $http.get('/uniqueid?for=user')
-                    .success(function getIdSucess(data) {
-                        account.id = data;
-                        account.likedIdeas = [];
-                        $http.post('/signup', account)
-                            .success(successCb)
-                            .error(errorCb);
-                    })
-                    .error(function getIdFailed(data, status) {
-                        console.log(status);
-                    });
-            };
-
             this.isUserLoggedIn = function isUserLoggedIn() {
                 if (typeof $rootScope.account === 'undefined') {
                     return false;
@@ -76,17 +61,6 @@ angular.module('flintAndSteel')
                     .error(errorCb);
             };
 
-            this.checkValidUsername = function checkValidUsername(username, successCb, errorCb) {
-                if (username) {
-                    $http.get('/isuniqueuser?user=' + username)
-                        .success(successCb)
-                        .error(errorCb);
-                }
-                else {
-                    return false;
-                }
-            };
-
             this.getUserById = function getUserById(userId, successCb, errorCb) {
                 if (userId) {
                     $http.get('/user?id=' + userId)
@@ -100,14 +74,12 @@ angular.module('flintAndSteel')
 
             return {
                 checkLogin: this.checkLogin,
-                addUser: this.addUser,
                 isUserLoggedIn: this.isUserLoggedIn,
                 logout: this.logout,
                 getProperty: this.getProperty,
                 likeIdea: this.likeIdea,
                 unlikeIdea: this.unlikeIdea,
                 updateAccount: this.updateAccount,
-                checkValidUsername: this.checkValidUsername,
                 getUserById: this.getUserById
             };
         }

--- a/src/users/loginSvc/loginSvc.js
+++ b/src/users/loginSvc/loginSvc.js
@@ -34,12 +34,6 @@ angular.module('flintAndSteel')
                 return $rootScope.account[propertyName];
             };
 
-            this.updateAccount = function updateAccount(account, successCb, errorCb) {
-                $http.post('/updateaccount', account)
-                    .success(successCb)
-                    .error(errorCb);
-            };
-
             this.getUserById = function getUserById(userId, successCb, errorCb) {
                 if (userId) {
                     $http.get('/user?id=' + userId)
@@ -56,7 +50,6 @@ angular.module('flintAndSteel')
                 isUserLoggedIn: this.isUserLoggedIn,
                 logout: this.logout,
                 getProperty: this.getProperty,
-                updateAccount: this.updateAccount,
                 getUserById: this.getUserById
             };
         }

--- a/src/users/loginSvc/loginSvc.js
+++ b/src/users/loginSvc/loginSvc.js
@@ -35,26 +35,6 @@ angular.module('flintAndSteel')
                 return $rootScope.account[propertyName];
             };
 
-            this.likeIdea = function likeIdea(ideaId) {
-                $rootScope.account.likedIdeas.push(ideaId);
-                this.updateAccount($rootScope.account, function accountUpdateSuccess() {
-                    // nothing *really* needs to happen here
-                }, function accountUpdateError(data, status) {
-                    console.log(status);
-                });
-            };
-
-            this.unlikeIdea = function unlikeIdea(ideaId) {
-                _.remove($rootScope.account.likedIdeas, function(item) {
-                    return item === ideaId;
-                });
-                this.updateAccount($rootScope.account, function accountUpdateSuccess() {
-                    // nothing *really* needs to happen here
-                }, function accountUpdateError(data, status) {
-                    console.log(status);
-                });
-            };
-
             this.updateAccount = function updateAccount(account, successCb, errorCb) {
                 $http.post('/updateaccount', account)
                     .success(successCb)
@@ -77,8 +57,6 @@ angular.module('flintAndSteel')
                 isUserLoggedIn: this.isUserLoggedIn,
                 logout: this.logout,
                 getProperty: this.getProperty,
-                likeIdea: this.likeIdea,
-                unlikeIdea: this.unlikeIdea,
                 updateAccount: this.updateAccount,
                 getUserById: this.getUserById
             };

--- a/src/users/loginSvc/loginSvc.js
+++ b/src/users/loginSvc/loginSvc.js
@@ -1,5 +1,4 @@
 /* global angular */
-/* global _ */
 
 angular.module('flintAndSteel')
 .factory('loginSvc',

--- a/src/users/loginSvc/loginSvc.mock.js
+++ b/src/users/loginSvc/loginSvc.mock.js
@@ -32,9 +32,6 @@ angular.module('flintAndSteel')
                         loggedIn = false;
                     }
                 },
-                addUser: function addUser() {
-                    throw new NotImplementedException('addUser');
-                },
                 isUserLoggedIn: function isUserLoggedIn() {
                     return loggedIn;
                 },
@@ -52,9 +49,6 @@ angular.module('flintAndSteel')
                 },
                 updateAccount: function updateAccount() {
                     throw new NotImplementedException('updateAccount');
-                },
-                checkValidUsername: function checkValidUsername() {
-                    throw new NotImplementedException('checkValidUsername');
                 },
                 getUserById: function getUserById() {
                     return mockUserAccount;

--- a/src/users/loginSvc/loginSvc.mock.js
+++ b/src/users/loginSvc/loginSvc.mock.js
@@ -41,12 +41,6 @@ angular.module('flintAndSteel')
                 getProperty: function getProperty(propertyName) {
                     return mockUserAccount[propertyName];
                 },
-                likeIdea: function likeIdea() {
-                    throw new NotImplementedException('likeIdea');
-                },
-                unlikeIdea: function unlikeIdea() {
-                    throw new NotImplementedException('unlikeIdea');
-                },
                 updateAccount: function updateAccount() {
                     throw new NotImplementedException('updateAccount');
                 },

--- a/src/users/loginSvc/loginSvc.mock.js
+++ b/src/users/loginSvc/loginSvc.mock.js
@@ -41,9 +41,6 @@ angular.module('flintAndSteel')
                 getProperty: function getProperty(propertyName) {
                     return mockUserAccount[propertyName];
                 },
-                updateAccount: function updateAccount() {
-                    throw new NotImplementedException('updateAccount');
-                },
                 getUserById: function getUserById() {
                     return mockUserAccount;
                 }

--- a/src/users/loginSvc/loginSvc.mock.js
+++ b/src/users/loginSvc/loginSvc.mock.js
@@ -13,14 +13,6 @@ angular.module('flintAndSteel')
                 likedIdeas: [ 'mock_idea' ]
             };
 
-            function NotImplementedException(call) {
-                this.name = 'NotImplementedException';
-                this.message = 'Method ' + call + ' has not been implemented!';
-                this.toString = function() {
-                    return this.name + ': ' + this.message;
-                };
-            }
-
             var loggedIn = false;
 
             return {

--- a/src/users/loginSvc/loginSvc.spec.js
+++ b/src/users/loginSvc/loginSvc.spec.js
@@ -63,28 +63,6 @@ describe('loginSvc', function() {
         });
     });
 
-    describe('loginSvc.addUser', function() {
-        var addUserHandler, uniqueIdHandler;
-
-        beforeEach(function() {
-            addUserHandler = $httpBackend.whenPOST('/signup', dummyUser)
-                                .respond(201, 'Created');
-            uniqueIdHandler = $httpBackend.whenGET('/uniqueid?for=user')
-                                .respond(200, 9001);
-        });
-
-        it('should register a new user', function() {
-            $httpBackend.expectGET('/uniqueid?for=user');
-            $httpBackend.expectPOST('/signup', dummyUser);
-
-            loginSvc.addUser(dummyUser, function(data) {
-                expect(data).toBe('Created');
-            }, function() { });
-
-            $httpBackend.flush();
-        });
-    });
-
     describe('loginSvc.isUserLoggedIn', function() {
 
         it('should return false for no logged in user', function() {
@@ -200,36 +178,6 @@ describe('loginSvc', function() {
             $httpBackend.flush();
         });
 
-    });
-
-    describe('loginSvc.checkValidUsername', function() {
-        var checkValidUsernameHandler;
-
-        beforeEach(function() {
-            checkValidUsernameHandler = $httpBackend.whenGET('/isuniqueuser?user=dummy')
-                                            .respond(200, true);
-        });
-
-        it('should return true for a unique user', function() {
-            $httpBackend.expectGET('/isuniqueuser?user=dummy');
-
-            loginSvc.checkValidUsername('dummy', function(data) {
-                expect(data).toBe(true);
-            }, function() { });
-
-            $httpBackend.flush();
-        });
-
-        it('should return false for a duplicate user', function() {
-            checkValidUsernameHandler.respond(200, false);
-            $httpBackend.expectGET('/isuniqueuser?user=dummy');
-
-            loginSvc.checkValidUsername('dummy', function(data) {
-                expect(data).toBe(false);
-            }, function() { });
-
-            $httpBackend.flush();
-        });
     });
 
 });

--- a/src/users/loginSvc/loginSvc.spec.js
+++ b/src/users/loginSvc/loginSvc.spec.js
@@ -117,47 +117,6 @@ describe('loginSvc', function() {
         });
     });
 
-    describe('loginSvc.likeIdea', function() {
-        var dummyLikedIdea;
-
-        beforeEach(function() {
-            dummyLikedIdea = 'dummy_liked_idea';
-            $rootScope.account = dummyUser;
-
-            spyOn(loginSvc, 'updateAccount').and.callFake(function(account, successCb) {
-                successCb('OK');
-            });
-        });
-
-        it('should add the ideaId to the array of liked ideas', function() {
-            loginSvc.likeIdea(dummyLikedIdea);
-
-            expect($rootScope.account.likedIdeas).toEqual(jasmine.arrayContaining([dummyLikedIdea]));
-        });
-    });
-
-    describe('loginSvc.unlikeIdea', function() {
-        var dummyLikedIdea;
-
-        beforeEach(function() {
-            dummyLikedIdea = 'dummy_liked_idea';
-            $rootScope.account = dummyUser;
-            $rootScope.account.likedIdeas.push(dummyLikedIdea);
-
-            spyOn(loginSvc, 'updateAccount').and.callFake(function(account, successCb) {
-                successCb('OK');
-            });
-        });
-
-        it('should add the ideaId to the array of liked ideas', function() {
-            expect($rootScope.account.likedIdeas).toEqual(jasmine.arrayContaining([dummyLikedIdea]));
-
-            loginSvc.unlikeIdea(dummyLikedIdea);
-
-            expect($rootScope.account.likedIdeas).not.toEqual(jasmine.arrayContaining([dummyLikedIdea]));
-        });
-    });
-
     describe('loginSvc.updateAccount', function() {
         var updateAccountHandler, updatedUser;
 

--- a/src/users/loginSvc/loginSvc.spec.js
+++ b/src/users/loginSvc/loginSvc.spec.js
@@ -115,26 +115,4 @@ describe('loginSvc', function() {
         });
     });
 
-    describe('loginSvc.updateAccount', function() {
-        var updateAccountHandler, updatedUser;
-
-        beforeEach(function() {
-            updatedUser = dummyUser;
-            updatedUser.username = 'theBestDummyV2';
-            updateAccountHandler = $httpBackend.whenPOST('/updateaccount', updatedUser)
-                                        .respond(200, 'OK');
-        });
-
-        it('should update the user account', function() {
-            $httpBackend.expectPOST('/updateaccount', updatedUser);
-
-            loginSvc.updateAccount(updatedUser, function(data) {
-                expect(data).toBe('OK');
-            }, function() { });
-
-            $httpBackend.flush();
-        });
-
-    });
-
 });

--- a/src/users/loginSvc/loginSvc.spec.js
+++ b/src/users/loginSvc/loginSvc.spec.js
@@ -4,8 +4,6 @@
 /* global inject */
 /* global it */
 /* global expect */
-/* global spyOn */
-/* global jasmine */
 
 describe('loginSvc', function() {
     "use strict";


### PR DESCRIPTION
Will close issue #164

As of the time of submitting this PR, the following are atomic database operations:
* Adding a comment to an idea (already implemented)
* Removing a comment to an idea (already implemented)
* Liking an idea
* Unliking an idea
* Adding a back to an idea
* Removing a back from an idea (untested since that functionality doesn't exist)

Things that are still needed:
* Editing a back (this might be challenging)
* Editing a comment (not yet implemented, but that should also be atomic for when it does get implemented. Might be outside scope of this PR)
* Editing an update (not yet implemented, but that should also be atomic for when it does get implemented. Might be outside scope of this PR)
* Adding an update to an idea
* Removing an update from an idea
* Anything team related

Why is there a concurrency issue? Anytime we call IdeaSvc.updateIdea in the client code, we are passing the entire Idea object to the server and overwriting it. So if 2 users submit a comment at the same time, only the second comment will show. We need to be updating tiny sections of the idea instead using atomic operations instead.

More to come, but feel free to have a look now:

@YashdalfTheGray @davethenipper @alanlgirard @monotkate @bcbrennecke @LongArmMcGee @Daviddt17