### PR TITLE
Fixed order of updates - doesn't always reroute to home on logout

### DIFF
--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -89,7 +89,7 @@
                         </md-card-content>
                     </md-card>
                     <md-list>
-                        <md-list-item class="md-2-line" ng-repeat="update in idea.updates | orderBy: 'time'" ng-show="idea.updates" ng-mouseover="hoverUpdate = true" ng-mouseout="hoverUpdate = false">
+                        <md-list-item class="md-2-line" ng-repeat="update in idea.updates | orderBy: '-time'" ng-show="idea.updates" ng-mouseover="hoverUpdate = true" ng-mouseout="hoverUpdate = false">
                             <div ng-show="(ideasView.isUserAuthorOfUpdate($index) || ideasView.isUserAuthor()) && update.deleted !== true && hoverUpdate === true">
                                 <md-button class="md-icon-button" aria-label="Delete Update" ng-click= "deleteUpdate($index)">
                                     <i class="material-icons icon-button-adjust">&#xE14C;</i>

--- a/src/navigation/toolbar.js
+++ b/src/navigation/toolbar.js
@@ -106,7 +106,14 @@ angular.module('flintAndSteel')
                 var accountName = loginSvc.getProperty('name');
                 loginSvc.logout();
                 toastSvc.show(accountName + ' has been logged out!');
-                $state.go('home');
+
+                // Reload if editing data to clear partial content
+                if ($state.includes('idea')) {
+                    $state.reload('idea');
+                }
+                else if ($state.includes('addidea')) {
+                    $state.go('home');
+                }
             };
 
             // Re-route to account page from menu

--- a/src/users/accountView/accountView.js
+++ b/src/users/accountView/accountView.js
@@ -28,13 +28,7 @@ angular.module('flintAndSteel')
 
                 toastSvc.show(accountName + ' has been logged out!', { duration: 5000 });
 
-                // Reload if editing data to clear partial content
-                if ($state.includes('idea')) {
-                    $state.reload('idea');
-                }
-                else if ($state.includes('addidea')) {
-                    $state.go('home');
-                }
+                $state.go('home');
             };
         }
     ]

--- a/src/users/accountView/accountView.js
+++ b/src/users/accountView/accountView.js
@@ -28,7 +28,13 @@ angular.module('flintAndSteel')
 
                 toastSvc.show(accountName + ' has been logged out!', { duration: 5000 });
 
-                $state.go('home');
+                // Reload if editing data to clear partial content
+                if ($state.includes('idea')) {
+                    $state.reload('idea');
+                }
+                else if ($state.includes('addidea')) {
+                    $state.go('home');
+                }
             };
         }
     ]


### PR DESCRIPTION
So this is pretty minor. 
(1) I realized that I'd goofed the order of updates on one of my fixes so I fixed that, the most recent update now presents at the top.

(2) I was getting really irritated during testing that it always re-routed to home on logout.  What I added was refreshing the page if there was potentially edits going on during a logout which should wipe any data left unfinished by reloading the controller.  It will reload ideaView and reroute addidea to home.  Any other page it will leave untouched since is far as I'm aware there should be no accessible data that would need to be cleared.  If people don't like this idea or I'm missing something, just let me know.  

@YashdalfTheGray @Mctalian @alanlgirard 

