### PR TITLE
Icon Change and Idea in Browse Update

### DIFF
--- a/database-schema.json
+++ b/database-schema.json
@@ -42,7 +42,7 @@
             {
                 "text": "",
                 "authorId": "one user._id",
-                "type": "",
+                "types": "",
                 "timeCreated": "",
                 "timeModified": ""
             }

--- a/server/ideas/ideaModel.js
+++ b/server/ideas/ideaModel.js
@@ -19,7 +19,8 @@ function Idea(title, description, authorId, eventId, tags, rolesreq) {
     this.backs = [{
         text: "Idea Owner",
         authorId: this.authorId,
-        time: new Date().toISOString(),
+        timeCreated: new Date().toISOString(),
+        timeModified: now,
         types: [{name: "Owner", _lowername: "owner"}]
     }];
     this.team = [{memberId: this.authorId}];

--- a/server/ideas/ideaModel.js
+++ b/server/ideas/ideaModel.js
@@ -20,7 +20,7 @@ function Idea(title, description, authorId, eventId, tags, rolesreq) {
         text: "Idea Owner",
         authorId: this.authorId,
         timeCreated: new Date().toISOString(),
-        timeModified: now,
+        timeModified: '',
         types: [{name: "Owner", _lowername: "owner"}]
     }];
     this.team = [{memberId: this.authorId}];

--- a/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
+++ b/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
@@ -1,38 +1,54 @@
 <md-card>
-    <md-tooltip md-visible="demo.showTooltip" layout-wrap>
-    {{idea.abstract}}
-    </md-tooltip>
     <md-card-content>
     <div flex="85">
         <div><strong>{{idea.title}}</strong></div>
         <div layout="row">
             <div layout="row" layout-align="center center">
-                <identicon username='idea.author.username' size='18'></identicon>
+                <identicon username='idea.author.username' size='14'></identicon>
             </div>
             <span>&nbsp;</span>
-            <div class="accent-text">{{idea.author.name}}</div>
+            <div class="accent-text author-accent">{{idea.author.name}}</div>
         </div>
     </div>
     <div flex layout="row">
         <div layout="row">
             <span>
-                <ng-pluralize count={{idea.likes}} 
-                     when="{'0': '{} Likes',
-                            'one': '{} Like',
-                            'other': '{} Likes'}">
-                </ng-pluralize>
-                &nbsp;
-                <ng-pluralize count={{idea.backs}} 
-                     when="{'0': '{} Backs',
-                            'one': '{} Back',
-                            'other': '{} Backs'}">
-                </ng-pluralize>
-                &nbsp;and&nbsp;            
-                <ng-pluralize count={{idea.team}} 
-                     when="{'0': '{} People',
-                            'one': '{} Person',
-                            'other': '{} People'}">
-                </ng-pluralize>
+                <md-button class="md-icon-button" aria-label="Like">
+                    {{idea.likes}}
+                    <i class="material-icons icon-button-adjust" ng-show="!isUserLiked()">&#xE87E;</i>
+                    <i class="material-icons icon-button-adjust" ng-show="isUserLiked()">&#xE87D;</i>
+                    <md-tooltip md-direction="bottom">
+                        <ng-pluralize count="idea.likes" 
+                             when="{'0': 'Likes',
+                                    'one': 'Like',
+                                    'other': 'Likes'}">
+                        </ng-pluralize>
+                    </md-tooltip>
+                </md-button>
+                <md-button class="md-icon-button" aria-label="Back">
+                    {{idea.backs}}
+                    <i class="material-icons icon-button-adjust" ng-show="!hasUserBacked()">&#xE893;</i>
+                    <i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE892;</i>
+                    <md-tooltip md-direction="bottom">
+                        <ng-pluralize count="idea.backs"
+                            when="{'0': 'Backs',
+                                   'one': 'Back',
+                                   'other': 'Backs'}">
+                        </ng-pluralize>
+                    </md-tooltip>
+                </md-button>
+                <md-button class="md-icon-button" aria-label="Back">
+                    {{idea.team}}
+                    <i class="material-icons icon-button-adjust" ng-show="!hasUserBacked()">&#xE7FC;</i>
+                    <i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE7FB;</i>
+                    <md-tooltip md-direction="bottom">
+                        <ng-pluralize count={{idea.team}} 
+                             when="{'0': 'People',
+                                    'one': 'Person',
+                                    'other': 'People'}">
+                        </ng-pluralize>
+                    </md-tooltip>
+                </md-button>
             </span>
         </div>
     </div>

--- a/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
+++ b/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
@@ -43,9 +43,9 @@
                     <!--<i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE7FB;</i>-->
                     <md-tooltip md-direction="bottom">
                         <ng-pluralize count={{idea.team}} 
-                             when="{'0': 'People',
-                                    'one': 'Person',
-                                    'other': 'People'}">
+                             when="{'0': 'Team Members',
+                                    'one': 'Team Member',
+                                    'other': 'Team Members'}">
                         </ng-pluralize>
                     </md-tooltip>
                 </md-button>

--- a/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
+++ b/src/ideas/ideaItemBrowse/ideaItemBrowse.tpl.html
@@ -15,8 +15,8 @@
             <span>
                 <md-button class="md-icon-button" aria-label="Like">
                     {{idea.likes}}
-                    <i class="material-icons icon-button-adjust" ng-show="!isUserLiked()">&#xE87E;</i>
-                    <i class="material-icons icon-button-adjust" ng-show="isUserLiked()">&#xE87D;</i>
+                    <i class="material-icons icon-button-adjust">&#xE87E;</i>
+                    <!--<i class="material-icons icon-button-adjust" ng-show="isUserLiked()">&#xE87D;</i>-->
                     <md-tooltip md-direction="bottom">
                         <ng-pluralize count="idea.likes" 
                              when="{'0': 'Likes',
@@ -27,8 +27,8 @@
                 </md-button>
                 <md-button class="md-icon-button" aria-label="Back">
                     {{idea.backs}}
-                    <i class="material-icons icon-button-adjust" ng-show="!hasUserBacked()">&#xE893;</i>
-                    <i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE892;</i>
+                    <i class="material-icons icon-button-adjust">&#xE893;</i>
+                    <!--<i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE892;</i>-->
                     <md-tooltip md-direction="bottom">
                         <ng-pluralize count="idea.backs"
                             when="{'0': 'Backs',
@@ -39,8 +39,8 @@
                 </md-button>
                 <md-button class="md-icon-button" aria-label="Back">
                     {{idea.team}}
-                    <i class="material-icons icon-button-adjust" ng-show="!hasUserBacked()">&#xE7FC;</i>
-                    <i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE7FB;</i>
+                    <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+                    <!--<i class="material-icons icon-button-adjust" ng-show="hasUserBacked()">&#xE7FB;</i>-->
                     <md-tooltip md-direction="bottom">
                         <ng-pluralize count={{idea.team}} 
                              when="{'0': 'People',

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -418,21 +418,6 @@ angular.module('flintAndSteel')
                 return false;
             };
 
-            $scope.showEditTeam = function(ev) {
-                var teamObj = '';
-
-                $mdDialog.show({
-                    controller: 'DialogBackCtrl',
-                    templateUrl: 'ideas/ideaTeam/ideaEditTeam.tpl.html',
-                    parent: angular.element(document.body),
-                    targetEvent: ev,
-                    clickOutsideToClose: true,
-                    locals: {
-                        backingObj: null
-                    }
-                })
-            };
-
             ///////////////////////
             // BACKING FUNCTIONS //
             ///////////////////////

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -483,6 +483,7 @@ angular.module('flintAndSteel')
                             text: ctrl.editBackText,
                             authorId: back.authorId,
                             timeCreated: back.timeCreated,
+                            timeModified: back.timeModified,
                             types: $scope.selectedTypes
                         };
                     }

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -212,7 +212,8 @@ angular.module('flintAndSteel')
                     obj = {
                         text: ctrl.newBack,
                         authorId: loginSvc.getProperty('_id'),
-                        time: now,
+                        timeCreated: now,
+                        timeModified: '',
                         types: $scope.selectedTypes
                     };
 
@@ -506,8 +507,7 @@ angular.module('flintAndSteel')
                         newBack = {
                             text: ctrl.editBackText,
                             authorId: back.authorId,
-                            time: back.time,
-                            timeModified: now,
+                            timeCreated: back.timeCreated,
                             types: $scope.selectedTypes
                         };
                     }
@@ -515,7 +515,8 @@ angular.module('flintAndSteel')
                         newBack = {
                             text: ctrl.editBackText,
                             authorId: back.authorId,
-                            time: back.time,
+                            timeCreated: back.timeCreated,
+                            timeModified: now,
                             types: $scope.selectedTypes
                         };
                     }

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -4,9 +4,10 @@
 /* global EventSource */
 
 // Dialog Controller used for controlling the behavior of the dialog
-//   used for login.
+//   used for backing.
 function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
     "use strict";
+
     // Populate values based off current back info
     $scope.types = ideaSvc.getBackTypeChips();
     $scope.backText = backingObj.text;
@@ -35,6 +36,7 @@ function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
     $scope.cancel = function() {
         $mdDialog.cancel();
     };
+
     // what happens when you hit the back idea button
     $scope.backIdea = function() {
         $mdDialog.hide($scope.backObject());
@@ -49,7 +51,7 @@ function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
 
         return obj;
     };
-    
+
     // add checked types to list
     $scope.toggle = function(item, i) {
         var idx = -1;
@@ -69,8 +71,7 @@ function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
         else {
             $scope.selectTypes.push(item);
             $scope.types[i].checked = true;
-        }
-        
+        }  
     };
 }
 
@@ -299,52 +300,6 @@ angular.module('flintAndSteel')
                 return results;
             };
 
-            $scope.openLikes = function openLikes(ev, likesArray) {
-                $mdDialog.show({
-                    parent: angular.element(document.body),
-                    targetEvent: ev,
-                    template:
-                        '<md-dialog aria-label="Users dialog">' +
-                        '   <md-toolbar>' +
-                        '       <div class="md-toolbar-tools">' +
-                        '           <h2>Users who liked this idea</h2>' +
-                        '       </div>' +
-                        '   </md-toolbar>' +
-                        '   <md-dialog-content>' +
-                        '       <md-list>' +
-                        '           <md-list-item ng-if="users.length > 0" ng-repeat="user in users">' +
-                        '               <div layout="row">' +
-                        '                   <div layout="row" layout-align="center center">' +
-                        '                       <identicon username="user.user.username" size="24"></identicon>' +
-                        '                   </div>' +
-                        '                   <span>&nbsp;</span>' +
-                        '                   {{user.user.name}}' +
-                        '               </div>' +
-                        '           </md-list-item>' +
-                        '           <md-list-item ng-if="users.length === 0">' +
-                        '               <div>No likes yet!</div>' +
-                        '           </md-list-item>' +
-                        '       </md-list>' +
-                        '   </md-dialog-content>' +
-                        '   <div class="md-actions">' +
-                        '       <md-button ng-click="closeDialog()" class="md-primary">' +
-                        '           Close' +
-                        '       </md-button>' +
-                        '   </div>' +
-                        '</md-dialog>',
-                    locals: {
-                        users: likesArray
-                    },
-                    controller: function($scope, $mdDialog, users) {
-                        $scope.users = users;
-                        console.log($scope.users);
-                        $scope.closeDialog = function() {
-                            $mdDialog.hide();
-                        };
-                    }
-                });
-            };
-
             $scope.isUserLoggedIn = loginSvc.isUserLoggedIn;
 
             $scope.ideaHasImage = function() {
@@ -390,6 +345,21 @@ angular.module('flintAndSteel')
                 });
             };
 
+            ctrl.isUserAuthor = function() {
+                if (loginSvc.isUserLoggedIn() && loginSvc.getProperty('_id') === $scope.idea.authorId) {
+                    return true;
+                }
+                return false;
+            };
+
+            ////////////////////
+            // TEAM FUNCTIONS //
+            ////////////////////
+
+            $scope.focusTeam = function() {
+                $scope.selectedTab = 3;
+            };
+
             ctrl.updateTeam = function() {
                 // Zero out the array
                 $scope.idea.team = [];
@@ -413,13 +383,6 @@ angular.module('flintAndSteel')
                     });
 
                 toastSvc.show('Team has been updated!');
-            };
-
-            ctrl.isUserAuthor = function() {
-                if (loginSvc.isUserLoggedIn() && loginSvc.getProperty('_id') === $scope.idea.authorId) {
-                    return true;
-                }
-                return false;
             };
 
             ctrl.isUserMemberOfTeam = function() {
@@ -455,9 +418,28 @@ angular.module('flintAndSteel')
                 return false;
             };
 
+            $scope.showEditTeam = function(ev) {
+                var teamObj = '';
+
+                $mdDialog.show({
+                    controller: 'DialogBackCtrl',
+                    templateUrl: 'ideas/ideaTeam/ideaEditTeam.tpl.html',
+                    parent: angular.element(document.body),
+                    targetEvent: ev,
+                    clickOutsideToClose: true,
+                    locals: {
+                        backingObj: null
+                    }
+                })
+            };
+
             ///////////////////////
             // BACKING FUNCTIONS //
             ///////////////////////
+
+            $scope.focusBack = function() {
+                $scope.selectedTab = 2;
+            };
 
             // Function used to trigger dialog for adding or editting a back
             $scope.showAddBack = function(ev) {

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -225,7 +225,7 @@ angular.module('flintAndSteel')
                     obj = {
                         text: ctrl.newUpdate,
                         authorId: loginSvc.getProperty('_id'),
-                        time: now
+                        timeCreated: now
                     };
 
                     ctrl.newUpdate = '';
@@ -269,7 +269,15 @@ angular.module('flintAndSteel')
                     else {
                         var copyObj = angular.copy(obj);
                         delete copyObj.author; // author object is not stored in database
-                        ideaSvc.removeInteraction($scope.idea._id, type, copyObj,
+                        delete copyObj.isInTeam;
+                        var backObjs = {
+                            text: copyObj.text,
+                            authorId: copyObj.authorId,
+                            types: copyObj.types,
+                            timeCreated: copyObj.timeCreated,
+                            timeModified: copyObj.timeModified
+                        };
+                        ideaSvc.removeInteraction($scope.idea._id, type, backObjs,
                             function success() {
                                 ctrl.refreshIdea();
                             },

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -209,20 +209,6 @@ describe('IdeasViewCtrl', function() {
         });
     });
 
-    describe('$scope.openLikes()', function() {
-
-        beforeEach(function() {
-            spyOn($mdDialog, 'show').and.callFake(function() {
-            });
-        });
-
-        it('should open a dialog when clicked', function() {
-            scope.openLikes({name: 'clickEvent'}, ['User 1', 'User 2']);
-
-            expect($mdDialog.show).toHaveBeenCalled();
-        });
-    });
-
     describe('editing the idea', function() {
         var mockIdea;
 

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -113,7 +113,7 @@
             </span>
         </span>
         <span flex ng-if="!isUserLoggedIn()">
-            <md-button class="md-icon-button" aria-label="Back">
+            <md-button class="md-icon-button" aria-label="Back" ng-click="focusBack()">
                 {{idea.backs.length}}
                 <i class="material-icons icon-button-adjust">&#xE893;</i>
             </md-button>
@@ -121,46 +121,73 @@
         </span>
         <span flex ng-if="isUserLoggedIn()">
             <span flex ng-if="!hasUserBacked()">
-                <md-button class="md-icon-button" aria-label="Back" ng-click="showAddBack($event)">
+                <md-button class="md-icon-button" aria-label="Back" ng-click="focusBack()">
                     {{idea.backs.length}}
                     <i class="material-icons icon-button-adjust">&#xE893;</i>
                 </md-button>
-                <md-tooltip md-direction="bottom">Contribute</md-tooltip>
+                <md-tooltip md-direction="bottom">
+                    <ng-pluralize count="idea.backs.length" 
+                        when="{'0': 'Backs',
+                               'one': 'Back',
+                               'other': 'Backs'}">
+                    </ng-pluralize>
+                </md-tooltip>
             </span>
             <span flex ng-if="hasUserBacked()">
-                <md-button class="md-icon-button" aria-label="Back" ng-click="showAddBack($event)">
+                <md-button class="md-icon-button" aria-label="Back" ng-click="focusBack()">
                     {{idea.backs.length}}
                     <i class="material-icons icon-button-adjust">&#xE892;</i>
                 </md-button>
-                <md-tooltip md-direction="bottom">Edit Contribution</md-tooltip>
+                <md-tooltip md-direction="bottom">Idea Backed</md-tooltip>
             </span>
         </span>
         <span flex ng-if="!isUserLoggedIn()">
-            <md-button class="md-icon-button" aria-label="Team">
+            <md-button class="md-icon-button" aria-label="Team" ng-click="focusTeam()">
                 {{idea.team.length}}
                 <i class="material-icons icon-button-adjust">&#xE7FC;</i>
             </md-button>
-            <md-tooltip md-direction="bottom">Login to Join Team</md-tooltip>
+            <md-tooltip md-direction="bottom">Login to Join</md-tooltip>
         </span>
         <span flex ng-if="isUserLoggedIn()">
-            <md-button class="md-icon-button" aria-label="Team">
-                {{idea.team.length}}
-                <i class="material-icons icon-button-adjust" ng-if="!ideasView.isUserMemberOfTeam()">&#xE7FC;</i>
-                <i class="material-icons icon-button-adjust" ng-if="ideasView.isUserMemberOfTeam()">&#xE7FB;</i>
-            </md-button>
-            <md-tooltip md-direction="bottom">
-                <ng-pluralize count={{idea.team.length}} 
-                     when="{'0': 'Team Members',
-                            'one': 'Team Member',
-                            'other': 'Team Members'}">
-                </ng-pluralize>
-            </md-tooltip>
+            <span flex ng-if="!ideasView.isUserMemberOfTeam() && !hasUserBacked()">
+                <md-button class="md-icon-button" aria-label="Team" ng-click="focusBack()">
+                    {{idea.team.length}}
+                    <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+                </md-button>
+                <md-tooltip md-direction="bottom">Back Idea First</md-tooltip>
+            </span>
+            <span flex ng-if="!ideasView.isUserMemberOfTeam() && hasUserBacked()">
+                <md-button class="md-icon-button" aria-label="Team" ng-click="focusTeam()">
+                    {{idea.team.length}}
+                    <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+                </md-button>
+                <md-tooltip md-direction="bottom">
+                    <ng-pluralize count="idea.team.length" 
+                        when="{'0': 'Team Members',
+                               'one': 'Team Member',
+                               'other': 'Team Members'}">
+                    </ng-pluralize>
+                </md-tooltip>
+            </span>
+            <span flex ng-if="ideasView.isUserMemberOfTeam()" ng-click="focusTeam()">
+                <md-button class="md-icon-button" aria-label="Team">
+                    {{idea.team.length}}
+                    <i class="material-icons icon-button-adjust">&#xE7FB;</i>
+                </md-button>
+                <md-tooltip md-direction="bottom">
+                    <ng-pluralize count="idea.team.length" 
+                        when="{'0': 'Team Members',
+                               'one': 'Team Member',
+                               'other': 'Team Members'}">
+                    </ng-pluralize>
+                </md-tooltip>
+            </span>
         </span>
     </md-card-content>
 </md-card>
 <md-card>
     <md-card-content>
-        <md-tabs md-dynamic-height md-border-bottom="">
+        <md-tabs md-dynamic-height md-border-bottom="" md-selected="selectedTab">
             <!-- Tab Used to show updates for the idea -->
             <md-tab label="Updates">
                 <md-content class="md-padding">

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -93,29 +93,23 @@
             <md-button class="md-icon-button" aria-label="Like">
                 {{idea.likes.length}}
                 <i class="material-icons icon-button-adjust">&#xE87E;</i>
-                <md-tooltip md-direction="bottom">
-                    Login to Like
-                </md-tooltip>
             </md-button>
+            <md-tooltip md-direction="bottom">Login to Like</md-tooltip>
         </span>
         <span flex ng-if="isUserLoggedIn()">
             <span flex ng-if="!isUserLiked()">
                 <md-button class="md-icon-button" aria-label="Like" ng-click="addNewInteraction('likes')">
                     {{idea.likes.length}}
                     <i class="material-icons icon-button-adjust">&#xE87E;</i>
-                    <md-tooltip md-direction="bottom">
-                        Like Idea
-                    </md-tooltip>
                 </md-button>
+                <md-tooltip md-direction="bottom">Like Idea</md-tooltip>
             </span>
             <span flex ng-if="isUserLiked()">
                 <md-button class="md-icon-button" aria-label="Unlike" ng-click="removeInteraction('likes')">
                 {{idea.likes.length}}
                     <i class="material-icons icon-button-adjust">&#xE87D;</i>
-                    <md-tooltip md-direction="bottom">
-                        Idea Liked
-                    </md-tooltip>
                 </md-button>
+                <md-tooltip md-direction="bottom">Idea Liked</md-tooltip>
             </span>
         </span>
         <span flex ng-if="!isUserLoggedIn()">
@@ -301,7 +295,7 @@
                 <md-content class="md-padding">
                     <md-button aria-label="email group" class="md-icon-button" ng-href="{{ideasView.parseTeamEmail()}}">
                             <i class="material-icons icon-button-adjust">&#xE0BE;</i>
-                            <md-tooltip md-direction="top">Email Team</md-tooltip>
+                            <md-tooltip md-direction="bottom">Email Team</md-tooltip>
                     </md-button>
                     <div layout="row">
                         <div layout="column">
@@ -346,13 +340,13 @@
                                 <md-list-item class="md-2-line" ng-show="ideasView.isUserAuthor() && idea.team.length > 1">
                                     <p>Your current team is shown below. You can edit who makes up your team at any time.</p>
                                 </md-list-item>
-                                <md-list-item class="md-2-line" ng-show="!ideasView.isUserAuthor() && !ideasView.isUserMemberOfTeam() && isUserLoggedIn() && idea.team.length > 0">
+                                <md-list-item class="md-3-line" ng-show="!ideasView.isUserAuthor() && !ideasView.isUserMemberOfTeam() && isUserLoggedIn() && idea.team.length > 0">
                                     <p>You are currently not part of the team.  If you would like to become part of the team, please back the idea so the author can be notified about your interest in being involved.</p>
                                 </md-list-item>
                                 <md-list-item class="md-2-line" ng-show="!ideasView.isUserAuthor() && ideasView.isUserMemberOfTeam() && isUserLoggedIn()">
                                     <p>You are part of the team!</p>
                                 </md-list-item>
-                                <md-list-item class="md-1-line" ng-repeat="back in idea.backs" ng-show="back.isInTeam" ng-mouseover="hovered = true" ng-mouseout="hovered = false">
+                                <md-list-item class="md-2-line" ng-repeat="back in idea.backs" ng-show="back.isInTeam" ng-mouseover="hovered = true" ng-mouseout="hovered = false">
                                     <div ng-show="hovered === true && !ideasView.isUserAuthor() && ideasView.isUserMemberOfTeam() && ideasView.isUserExactMemberOfTeam($index)">
                                         <md-button class="md-icon-button" aria-label="Remove From Team" ng-click="ideasView.removeUserFromTeam(back)">
                                             <i class="material-icons icon-button-adjust">&#xE14C;</i>
@@ -376,15 +370,15 @@
                     </div>
                     <div ng-show="ideasView.isUserAuthor()">
                         <md-button ng-show="ideasView.enableTeamEdit === false" class="md-raised md-primary margin-top" ng-click="ideasView.enableTeamEdit = true">
-                            <md-tooltip md-direction="top">Edit Team Members</md-tooltip>
+                            <md-tooltip md-direction="bottom">Edit Team Members</md-tooltip>
                             Edit
                         </md-button>
                         <md-button ng-show="ideasView.enableTeamEdit === true" class="md-raised md-primary margin-top" ng-click="ideasView.updateTeam()">
-                            <md-tooltip md-direction="top">Submit Team Members</md-tooltip>
+                            <md-tooltip md-direction="bottom">Submit Team Members</md-tooltip>
                             Submit
                         </md-button>
                         <md-button ng-show="ideasView.enableTeamEdit === true" class="md-raised md-primary margin-top" ng-click="ideasView.refreshTeam()">
-                            <md-tooltip md-direction="top">Cancel Team Member Edit</md-tooltip>
+                            <md-tooltip md-direction="bottom">Cancel Team Member Edit</md-tooltip>
                             Cancel
                         </md-button>
                     </div>

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -190,7 +190,7 @@
                         </md-card-content>
                     </md-card>
                     <md-list>
-                        <md-list-item class="md-2-line" ng-repeat="update in idea.updates | orderBy: '-time'" ng-show="idea.updates" ng-mouseover="hoverUpdate = true" ng-mouseout="hoverUpdate = false">
+                        <md-list-item class="md-2-line" ng-repeat="update in idea.updates | orderBy: '-timeCreated'" ng-show="idea.updates" ng-mouseover="hoverUpdate = true" ng-mouseout="hoverUpdate = false">
                             <div ng-show="(ideasView.isUserAuthorOfInteraction(update) || ideasView.isUserAuthor()) && hoverUpdate === true">
                                 <md-button class="md-icon-button" aria-label="Delete Update" ng-click= "removeInteraction('updates', update)">
                                     <i class="material-icons icon-button-adjust">&#xE14C;</i>
@@ -202,7 +202,7 @@
                                     <div layout="row" layout-align="center center">
                                         <identicon username='update.author.username' size='18'></identicon>
                                     </div>
-                                    <p>&nbsp;<email-link author-obj="update.author"></email-link><small class="extra-space-left" ng-bind="momentizeTime(update.time)"></small></p>
+                                    <p>&nbsp;<email-link author-obj="update.author"></email-link><small class="extra-space-left" ng-bind="momentizeTime(update.timeCreated)"></small></p>
                                 </div>
                             </div>
 

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -278,7 +278,7 @@
                             <div class="md-list-item-text">
                                 <h3>{{back.text}}
                                     <span class="extra-padding-left-sm">
-                                        <small ng-show="!hasBackBeenEdited(back)" ng-bind="momentizeTime(back.time)"></small>
+                                        <small ng-show="!hasBackBeenEdited(back)" ng-bind="momentizeTime(back.timeCreated)"></small>
                                         <small ng-show="hasBackBeenEdited(back)" ng-bind="momentizeModifiedTime(back.timeModified)"></small>
                                     </span>
                                 </h3>

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -121,7 +121,7 @@
         <span flex ng-if="!isUserLoggedIn()">
             <md-button class="md-icon-button" aria-label="Back">
                 {{idea.backs.length}}
-                <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+                <i class="material-icons icon-button-adjust">&#xE893;</i>
             </md-button>
             <md-tooltip ng-if="!hasUserBacked()" md-direction="bottom">Login to Back</md-tooltip>
         </span>
@@ -129,17 +129,38 @@
             <span flex ng-if="!hasUserBacked()">
                 <md-button class="md-icon-button" aria-label="Back" ng-click="showAddBack($event)">
                     {{idea.backs.length}}
-                    <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+                    <i class="material-icons icon-button-adjust">&#xE893;</i>
                 </md-button>
                 <md-tooltip md-direction="bottom">Contribute</md-tooltip>
             </span>
             <span flex ng-if="hasUserBacked()">
                 <md-button class="md-icon-button" aria-label="Back" ng-click="showAddBack($event)">
                     {{idea.backs.length}}
-                    <i class="material-icons icon-button-adjust">&#xE7FB;</i>
+                    <i class="material-icons icon-button-adjust">&#xE892;</i>
                 </md-button>
                 <md-tooltip md-direction="bottom">Edit Contribution</md-tooltip>
             </span>
+        </span>
+        <span flex ng-if="!isUserLoggedIn()">
+            <md-button class="md-icon-button" aria-label="Team">
+                {{idea.team.length}}
+                <i class="material-icons icon-button-adjust">&#xE7FC;</i>
+            </md-button>
+            <md-tooltip md-direction="bottom">Login to Join Team</md-tooltip>
+        </span>
+        <span flex ng-if="isUserLoggedIn()">
+            <md-button class="md-icon-button" aria-label="Team">
+                {{idea.team.length}}
+                <i class="material-icons icon-button-adjust" ng-if="!ideasView.isUserMemberOfTeam()">&#xE7FC;</i>
+                <i class="material-icons icon-button-adjust" ng-if="ideasView.isUserMemberOfTeam()">&#xE7FB;</i>
+            </md-button>
+            <md-tooltip md-direction="bottom">
+                <ng-pluralize count={{idea.team.length}} 
+                     when="{'0': 'Team Members',
+                            'one': 'Team Member',
+                            'other': 'Team Members'}">
+                </ng-pluralize>
+            </md-tooltip>
         </span>
     </md-card-content>
 </md-card>
@@ -243,10 +264,10 @@
                         <md-tooltip md-direction="bottom">Edit Contribution</md-tooltip>
                     </md-button>
                     <!-- Delete current backing -->
-                    <!--<md-button class="md-icon-button" ng-if="isUserLoggedIn()" ng-click="removeBack()" ng-disabled="!hasUserBacked()">
+                    <md-button class="md-icon-button" ng-if="isUserLoggedIn()" ng-click="removeBack()" ng-disabled="!hasUserBacked()">
                         <i class="material-icons icon-button-adjust">&#xE5CD;</i>
                         <md-tooltip md-direction="bottom">Delete Back</md-tooltip>
-                    </md-button>-->
+                    </md-button>
                     <md-list>
                         <md-list-item class="md-3-line" ng-repeat="back in idea.backs" ng-mouseover="hovered = true" ng-mouseout="hovered = false">
                             <div ng-show="hovered === true && ideasView.isUserAuthorOfInteraction(back)">


### PR DESCRIPTION
Changed the icon for backing.  Opinions welcome.  Mostly because I wanted to use the backing icon for team.  Added the team count in an idea page.

Also changed text on the ideas in browse from text to icons with tooltips and shrunk author a bit.  I think it simplifies and looks a lot better.  I plan on attaching them to the "hasBacked/Liked/isinTeam" functions later, but they're not part of ideaSvc and I have to figure out how to swing that first.  

Uncommented the delete button but I realized there are some discrepancies between the data in the front and and what the backend is supposed to have.  It doesn't do anything right now and I can comment it back up.  I'm hoping to get a look at these discrepancies this weekend because @alanlgirard and I pinpointed a bunch of them.

Minor change overall.  Unrelated to the issues I've got in my name for now which are both affected by the discrepancies.  @YashdalfTheGray @Mctalian @alanlgirard 

EDIT: Fixed some inconsistencies --
- Backers weren't actually set up to use the time modified/time created.  It should be working correctly now from what I can tell.  
- Set most idea tooltips to scroll down instead of the team tab scrolling up and the backers tab scrolling down.  
- Updates can't be edited right now (I believe), but their time was also set up incorrectly using time instead of timeModified.  Should be fixed now.  Fixes #186 I believe

EDIT2 (Because no one's checking, so I just keep adding things):
- Changed out the idea icons interact.  Now depending on what you should be doing with backers/teams it will focus on that tab. Backer indicator will push you to backer tab. Team indicator will push you to team tab unless you are logged in and have not backed, at which point it will push you to the backers tab
- Deleted the dialog info for showing who has liked the idea and the associated test.  Can put back if necessary but right now it's not being used anywhere so I nixed the code.