### PR TITLE
Fixes Edit Back, Enables Delete Back

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -140,6 +140,10 @@ module.exports = function(dbName, cb) {
                     console.error(chalk.bgRed(err));
                     cb(err);
                 }
+                else if (results.nMatched === 0) {
+                    console.error(chalk.yellow('No documents with id ' + id + ' were found.'));
+                    cb(null, results);
+                }
                 else {
                     // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' colletion.'), id);
                     cb(null, results);
@@ -166,6 +170,10 @@ module.exports = function(dbName, cb) {
                 if (err) {
                     console.error(chalk.bgRed(err));
                     cb(err);
+                }
+                else if (results.nMatched === 0) {
+                    console.error(chalk.yellow('No documents with id ' + id + ' were found.'));
+                    cb(null, results);
                 }
                 else {
                     // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), id);
@@ -195,6 +203,11 @@ module.exports = function(dbName, cb) {
                     console.error(chalk.bgRed(err));
                     cb(err);
                 }
+                else if (results.nMatched === 0) {
+                    console.error(chalk.yellow('No documents matching the following query were found:'));
+                    console.log(query);
+                    cb(null, results);
+                }
                 else {
                     // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), id);
                     cb(null, results);
@@ -221,6 +234,10 @@ module.exports = function(dbName, cb) {
                     console.error(chalk.bgRed(err));
                     cb(err);
                 }
+                else if (results.nMatched === 0) {
+                    console.error(chalk.yellow('No documents with id ' + id + ' were found.'));
+                    cb(null, results);
+                }
                 else {
                     // console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), id);
                     cb(null, results);
@@ -244,6 +261,11 @@ module.exports = function(dbName, cb) {
               if (err) {
                   console.error(chalk.bgRed(err));
                   cb(err);
+              }
+              else if (results.nMatched === 0) {
+                  console.error(chalk.yellow('No documents matching the following query were found:'));
+                  console.log(find);
+                  cb(null, results.value._id);
               }
               else {
                   //   console.log(chalk.bgGreen('Document with id %s updated in the ' + collection + ' collection.'), results.value._id);
@@ -270,6 +292,11 @@ module.exports = function(dbName, cb) {
                     console.error(chalk.bgRed(err));
                     cb(err);
                 }
+                else if (results.nMatched === 0) {
+                    console.error(chalk.yellow('No documents matching the following query were found:'));
+                    console.log(find);
+                    cb(null, results);
+                }
                 else {
                     // console.log(chalk.bgGreen('Document with ' + property + ' %s updated in the database.'), obj.email);
                     cb(null, results);
@@ -285,6 +312,10 @@ module.exports = function(dbName, cb) {
             if (err) {
                 console.error(chalk.bgRed(err));
                 cb(err);
+            }
+            else if (results.nMatched === 0) {
+                console.error(chalk.yellow('No documents with id ' + id + ' were found.'));
+                cb(null, results);
             }
             else {
                 // console.log(chalk.bgGreen('Document with id %s removed from the ' + collection + ' collection.'), id);

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -17,7 +17,7 @@ module.exports = function(db) {
 
     module.create = function(title, description, authorId, eventId, tags, rolesreq, cb) {
         var objAuthorId = new ObjectId(authorId);
-        var objEventId = eventId !== '' ? new ObjectId(eventId) : '';
+        var objEventId = eventId !== '' ? new ObjectId(eventId) : eventId;
         var idea = IdeaModel.create(title, description, objAuthorId, objEventId, tags, rolesreq);
         db.insertOne(COLLECTION, idea, function(err, doc) {
             cb(err, doc);

--- a/server/ideas/ideas.js
+++ b/server/ideas/ideas.js
@@ -16,7 +16,9 @@ module.exports = function(db) {
     var IdeasSingleton;
 
     module.create = function(title, description, authorId, eventId, tags, rolesreq, cb) {
-        var idea = IdeaModel.create(title, description, authorId, eventId, tags, rolesreq);
+        var objAuthorId = new ObjectId(authorId);
+        var objEventId = eventId !== '' ? new ObjectId(eventId) : '';
+        var idea = IdeaModel.create(title, description, objAuthorId, objEventId, tags, rolesreq);
         db.insertOne(COLLECTION, idea, function(err, doc) {
             cb(err, doc);
         });

--- a/src/ideas/ideaBack/ideaAddBack.tpl.html
+++ b/src/ideas/ideaBack/ideaAddBack.tpl.html
@@ -16,7 +16,7 @@
                 <p>Tag the type of your contribution (choose at least one)</p>
                 <div layout="row" layout-wrap>
                     <div ng-repeat="type in types" flex="50" ng-click="toggle(type, $index)">
-                        <md-checkbox>
+                        <md-checkbox ng-checked="type.checked">
                             {{type.name}}
                         </md-checkbox>
                     </div>

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -13,7 +13,7 @@ function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
     $scope.backText = backingObj.text;
     $scope.tempTypes = backingObj.types;
     $scope.selectTypes = []; // Variable used for scope issues
-    
+
     for (var k = 0; k < $scope.tempTypes.length; k++) {
         $scope.tempTypes[k].checked = true;
     }
@@ -71,7 +71,7 @@ function DialogBackCtrl($scope, $mdDialog, ideaSvc, backingObj) {
         else {
             $scope.selectTypes.push(item);
             $scope.types[i].checked = true;
-        }  
+        }
     };
 }
 
@@ -522,7 +522,9 @@ angular.module('flintAndSteel')
 
             $scope.removeBack = function() {
                 $scope.loadEditBack();
-                $scope.removeInteraction('back', $scope.userBack);
+                $scope.removeInteraction('backs', $scope.userBack);
+                ctrl.newBack = '';
+                $scope.selectedTypes = [];
             };
 
             // Checks if the current user has backed the current idea


### PR DESCRIPTION
Closes #199

Also deleting backs now work @monotkate, you nearly had it. You had `back` as the interactionType not `backs`. I tried to think of how we can make that better but gave up for now. Sorry for the confusion!

There is a bit of quirky behavior with the backing dialog. When you click in between line items it will implicitly check the backing type, but not display the checkmark. It's a bit odd. I am going to look into this.

In the meantime, @YashdalfTheGray, how much do these changes mess up your backend stuff?