### PR TITLE
Disable IE angular $http chaching

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -13,8 +13,8 @@ angular.module('flintAndSteel', [
     ]
 )
 .config([
-    '$urlRouterProvider', '$stateProvider', '$mdIconProvider', '$mdThemingProvider',
-    function($urlRouterProvider, $stateProvider, $mdIconProvider, $mdThemingProvider) {
+    '$urlRouterProvider', '$stateProvider', '$mdIconProvider', '$mdThemingProvider', '$httpProvider',
+    function($urlRouterProvider, $stateProvider, $mdIconProvider, $mdThemingProvider, $httpProvider) {
         "use strict";
 
         $stateProvider
@@ -99,6 +99,16 @@ angular.module('flintAndSteel', [
             'hue-1': 'A700'
         })
         .warnPalette('red');
+
+        // Initialize get if not there
+        if (!$httpProvider.defaults.headers.get) {
+            $httpProvider.defaults.headers.get = {};    
+        }
+
+        // Disable IE ajax request caching
+        $httpProvider.defaults.headers.get['If-Modified-Since'] = 'Mon, 26 Jul 1997 05:00:00 GMT';
+        $httpProvider.defaults.headers.get['Cache-Control'] = 'no-cache';
+        $httpProvider.defaults.headers.get['Pragma'] = 'no-cache';        
     }
 ]);
 

--- a/src/app.js
+++ b/src/app.js
@@ -108,7 +108,7 @@ angular.module('flintAndSteel', [
         // Disable IE ajax request caching
         $httpProvider.defaults.headers.get['If-Modified-Since'] = 'Mon, 26 Jul 1997 05:00:00 GMT';
         $httpProvider.defaults.headers.get['Cache-Control'] = 'no-cache';
-        $httpProvider.defaults.headers.get['Pragma'] = 'no-cache';        
+        $httpProvider.defaults.headers.get.Pragma = 'no-cache';
     }
 ]);
 


### PR DESCRIPTION
This is the solution to #207.

Since some of the default fields include hyphens, how do I go about using dot notation since that is demanded by our style checker?

@YashdalfTheGray @Mctalian @davethenipper @alanlgirard @LongArmMcGee @bcbrennecke @monotkate 