### PR TITLE
Event Tags: Part 1.5 of 3

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -15,7 +15,7 @@ module.exports = function(config) {
 
         // list of files / patterns to load in the browser
         files: [
-            
+
             'src/lib/angular/angular.js',
             'src/lib/angular-timeline/dist/angular-timeline.js',
             'src/lib/angular-mocks/angular-mocks.js',
@@ -33,10 +33,12 @@ module.exports = function(config) {
             'src/lib/lodash/lodash.js',
             'src/app.js',
             'src/about/about.js',
+            'src/events/eventSvc/eventSvc.mock.js',
             'src/ideas/ideaSvc/ideaSvc.mock.js',
             'src/users/userSvc/userSvc.mock.js',
             'src/toastSvc/toastSvc.js',
             'src/homeView/homeView.js',
+            'src/events/**/*.js',
             'src/ideas/**/*.js',
             'src/navigation/**/*.js',
             'src/users/**/*.js',

--- a/src/events/eventSvc/eventSvc.js
+++ b/src/events/eventSvc/eventSvc.js
@@ -1,0 +1,19 @@
+/* global angular */
+
+angular.module('flintAndSteel')
+.factory('eventSvc',
+    [
+        '$http',
+        function($http) {
+            "use strict";
+
+            this.getEvents = function getEvents() {
+                return $http.get('/events');
+            };
+
+            return {
+                getEvents: this.getEvents
+            };
+        }
+    ]
+);

--- a/src/events/eventSvc/eventSvc.mock.js
+++ b/src/events/eventSvc/eventSvc.mock.js
@@ -26,7 +26,7 @@ angular.module('flintAndSteel')
             ];
             return {
                 getEvents: function() {
-                    return $q.when(events);
+                    return $q.when({ data: events });
                 }
             };
         }

--- a/src/events/eventSvc/eventSvc.mock.js
+++ b/src/events/eventSvc/eventSvc.mock.js
@@ -1,0 +1,29 @@
+/* global angular */
+
+angular.module('flintAndSteel')
+.factory('eventSvcMock', [function() {
+    "use strict";
+
+    var now = new Date();
+    var events = [
+        {
+            _id: 0,
+            name: "The On-Going Event!",
+            location: "Right Here",
+            startDate: now,
+            endDate: new Date(now.getFullYear(), now.getMonth() + 1, now.getDate())
+        },
+        {
+            _id: 1,
+            name: "Expired Event",
+            location: "Over There",
+            startDate: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()),
+            endDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+        }
+    ];
+    return {
+        getEvents: function() {
+            return events;
+        }
+    };
+}]);

--- a/src/events/eventSvc/eventSvc.mock.js
+++ b/src/events/eventSvc/eventSvc.mock.js
@@ -1,29 +1,34 @@
 /* global angular */
 
 angular.module('flintAndSteel')
-.factory('eventSvcMock', [function() {
-    "use strict";
+.factory('eventSvcMock',
+    [
+        "$q",
+        function($q) {
+            "use strict";
 
-    var now = new Date();
-    var events = [
-        {
-            _id: 0,
-            name: "The On-Going Event!",
-            location: "Right Here",
-            startDate: now,
-            endDate: new Date(now.getFullYear(), now.getMonth() + 1, now.getDate())
-        },
-        {
-            _id: 1,
-            name: "Expired Event",
-            location: "Over There",
-            startDate: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()),
-            endDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+            var now = new Date();
+            var events = [
+                {
+                    _id: 0,
+                    name: "The On-Going Event!",
+                    location: "Right Here",
+                    startDate: now,
+                    endDate: new Date(now.getFullYear(), now.getMonth() + 1, now.getDate())
+                },
+                {
+                    _id: 1,
+                    name: "Expired Event",
+                    location: "Over There",
+                    startDate: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()),
+                    endDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+                }
+            ];
+            return {
+                getEvents: function() {
+                    return $q.when(events);
+                }
+            };
         }
-    ];
-    return {
-        getEvents: function() {
-            return events;
-        }
-    };
-}]);
+    ]
+);

--- a/src/events/eventSvc/eventSvc.spec.js
+++ b/src/events/eventSvc/eventSvc.spec.js
@@ -3,11 +3,13 @@
 /* global beforeEach */
 /* global inject */
 /* global it */
+/* global expect */
 
 describe('eventSvc', function() {
     "use strict";
 
     var eventSvc, $httpBackend, dummyEvents;
+    var now = new Date();
 
     beforeEach(module('flintAndSteel'));
 
@@ -51,7 +53,7 @@ describe('eventSvc', function() {
         it('it should return all the events', function() {
             $httpBackend.expectGET('/events');
 
-            ideaSvc.getEvents().then(function() { }, function() { });
+            eventSvc.getEvents().then(function() { }, function() { });
 
             $httpBackend.flush();
         });

--- a/src/events/eventSvc/eventSvc.spec.js
+++ b/src/events/eventSvc/eventSvc.spec.js
@@ -1,0 +1,60 @@
+/* global describe */
+/* global module */
+/* global beforeEach */
+/* global inject */
+/* global it */
+
+describe('eventSvc', function() {
+    "use strict";
+
+    var eventSvc, $httpBackend, dummyEvents;
+
+    beforeEach(module('flintAndSteel'));
+
+    beforeEach(inject(function(_eventSvc_, _$httpBackend_) {
+        eventSvc = _eventSvc_;
+        $httpBackend = _$httpBackend_;
+        dummyEvents = [
+            {
+                _id: 0,
+                name: "The On-Going Event!",
+                location: "Right Here",
+                startDate: now,
+                endDate: new Date(now.getFullYear(), now.getMonth() + 1, now.getDate())
+            },
+            {
+                _id: 1,
+                name: "Expired Event",
+                location: "Over There",
+                startDate: new Date(now.getFullYear(), now.getMonth() - 1, now.getDate()),
+                endDate: new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1)
+            }
+        ];
+    }));
+
+    afterEach(function() {
+        $httpBackend.verifyNoOutstandingExpectation();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+
+    it('should exist', function() {
+        expect(eventSvc).toBeDefined();
+    });
+
+    describe('eventSvc.getEvents', function() {
+        var getEventsHandler;
+
+        beforeEach(function() {
+            getEventsHandler = $httpBackend.whenGET('/events').respond(200, dummyEvents);
+        });
+
+        it('it should return all the events', function() {
+            $httpBackend.expectGET('/events');
+
+            ideaSvc.getEvents().then(function() { }, function() { });
+
+            $httpBackend.flush();
+        });
+
+    });
+});

--- a/src/ideas/addIdeaView/addIdeaView.js
+++ b/src/ideas/addIdeaView/addIdeaView.js
@@ -4,8 +4,8 @@
 angular.module('flintAndSteel')
 .controller('AddIdeaViewCtrl',
     [
-        '$scope', '$state', 'toastSvc', 'ideaSvc', 'userSvc',
-        function($scope, $state, toastSvc, ideaSvc, userSvc) {
+        '$scope', '$state', 'toastSvc', 'ideaSvc', 'userSvc', 'eventSvc',
+        function($scope, $state, toastSvc, ideaSvc, userSvc, eventSvc) {
             "use strict";
 
             if (!userSvc.isUserLoggedIn()) {
@@ -15,8 +15,17 @@ angular.module('flintAndSteel')
 
             $scope.idea = {};
             $scope.idea.tags = [];
+            $scope.idea.eventId = "";
             $scope.tagInput = "";
 
+            var nullEvent = {
+                _id: "",
+                name: "No Event"
+            };
+
+            ///////////////////
+            // TAG FUNCTIONS //
+            ///////////////////
             $scope.doesTagExist = function doesTagExist(tag) {
                 if ($scope.idea.tags.indexOf(tag) === -1) {
                     return false;
@@ -48,9 +57,26 @@ angular.module('flintAndSteel')
                 }
             };
 
+            /////////////////////
+            // EVENT FUNCTIONS //
+            /////////////////////
+
+            $scope.loadEvents = function() {
+                eventSvc.getEvents().then(function getEventsSuccess(response) {
+                    $scope.events = [nullEvent];
+                    $scope.events = $scope.events.concat(response.data);
+                }, function getEventsError(response) {
+                    $scope.events = [];
+                    console.log(response);
+                });
+            };
+
+            ////////////////////
+            // IDEA FUNCTIONS //
+            ////////////////////
+
             $scope.addNewIdea = function addNewIdea(ideaToAdd) {
                 ideaToAdd.authorId = userSvc.getProperty('_id');
-                ideaToAdd.eventId = "";
                 ideaToAdd.rolesreq = [];
                 ideaSvc.postIdea($scope.idea).then(function postIdeaSuccess(response) {
                     if (angular.isDefined(response.data.status) && response.data.status === 'Created') {

--- a/src/ideas/addIdeaView/addIdeaView.js
+++ b/src/ideas/addIdeaView/addIdeaView.js
@@ -63,8 +63,7 @@ angular.module('flintAndSteel')
 
             $scope.loadEvents = function() {
                 eventSvc.getEvents().then(function getEventsSuccess(response) {
-                    $scope.events = [nullEvent];
-                    $scope.events = $scope.events.concat(response.data);
+                    $scope.events = [nullEvent].concat(response.data);
                 }, function getEventsError(response) {
                     $scope.events = [];
                     console.log(response);

--- a/src/ideas/addIdeaView/addIdeaView.js
+++ b/src/ideas/addIdeaView/addIdeaView.js
@@ -28,7 +28,7 @@ angular.module('flintAndSteel')
                 var reNonAlpha = /[.,-\/#!$%\^&\*;:{}=\-_`~()<>\'\"@\[\]\|\\\?]/g;
                 tag = tag.replace(reNonAlpha, " ");
                 tag = _.capitalize(_.camelCase(tag));
-                if ($scope.idea.tags.length !== 5 && !$scope.doesTagExist(tag) && tag !== '') {                    
+                if ($scope.idea.tags.length !== 5 && !$scope.doesTagExist(tag) && tag !== '') {
                     $scope.idea.tags.push(tag);
                 }
             };
@@ -43,7 +43,9 @@ angular.module('flintAndSteel')
 
             $scope.removeTag = function removeTag(tag) {
                 var index = $scope.idea.tags.indexOf(tag);
-                $scope.idea.tags.splice(index, 1);
+                if (index >= 0) {
+                    $scope.idea.tags.splice(index, 1);
+                }
             };
 
             $scope.addNewIdea = function addNewIdea(ideaToAdd) {

--- a/src/ideas/addIdeaView/addIdeaView.spec.js
+++ b/src/ideas/addIdeaView/addIdeaView.spec.js
@@ -37,124 +37,132 @@ describe('AddIdeaViewCtrl', function() {
         expect(ctrl).toBeDefined();
     });
 
-    it('should add a new idea', function() {
-        var idea = {
-            title: 'Test Title',
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addNewIdea(idea);
+    describe('scope.addNewIdea', function() {
 
-        expect(ideaSvcMock.postIdea).toHaveBeenCalled();
-        expect(idea.eventId).toBe("");
-        expect(idea.rolesreq.length).toBe(0);
+        it('should add a new idea', function() {
+            var idea = {
+                title: 'Test Title',
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addNewIdea(idea);
+
+            expect(ideaSvcMock.postIdea).toHaveBeenCalled();
+            expect(idea.eventId).toBe("");
+            expect(idea.rolesreq.length).toBe(0);
+        });
+
+        it('should use the user\'s _id as the authorId', function() {
+            var idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addNewIdea(idea);
+
+            expect(idea.authorId).not.toBe(3);
+            expect(idea.authorId).toBe(1);
+        });
     });
 
-    it('should use the user\'s _id as the authorId', function() {
-        var idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addNewIdea(idea);
+    describe('scope.addTag', function() {
 
-        expect(idea.authorId).not.toBe(3);
-        expect(idea.authorId).toBe(1);
+        it('should add tag', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addTag('testTag3');
+
+            expect(scope.idea.tags.length).not.toBe(2);
+            expect(scope.idea.tags.length).toBe(3);
+            scope.idea = {};
+        });
+
+        it('should not add duplicate tags', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addTag('TestTag2');
+
+            expect(scope.idea.tags.length).not.toBe(3);
+            expect(scope.idea.tags.length).toBe(2);
+        });
+
+        it('should not add more than 5 tags', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2', 'TestTag3', 'TestTag4', 'TestTag5']
+            };
+            scope.addTag('TestTag6');
+
+            expect(scope.idea.tags.length).not.toBe(6);
+            expect(scope.idea.tags.length).toBe(5);
+        });
+
+        it('should not add a blank tag', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addTag('');
+
+            expect(scope.idea.tags.length).not.toBe(3);
+            expect(scope.idea.tags.length).toBe(2);
+        });
+
+        it('should remove special characters from tags', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addTag('hello!@world&*@');
+
+            expect(scope.idea.tags.length).toBe(3);
+            expect(scope.doesTagExist('hello!@world&*@')).toBe(false);
+            expect(scope.doesTagExist('HelloWorld')).toBe(true);
+        });
+
+        it('should use CamelCase for tags', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.addTag('This is a tag');
+
+            expect(scope.idea.tags.length).toBe(3);
+            expect(scope.doesTagExist('This is a tag')).toBe(false);
+            expect(scope.doesTagExist('ThisIsATag')).toBe(true);
+        });
     });
 
-    it('should add tag', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addTag('testTag3');
+    describe('scope.deleteTag', function() {
+        it('should delete tag', function() {
+            scope.idea = {
+                title: 'Test Title',
+                authorId: 3,
+                description: 'This is a test idea.',
+                tags: ['TestTag1', 'TestTag2']
+            };
+            scope.removeTag('TestTag2');
 
-        expect(scope.idea.tags.length).not.toBe(2);
-        expect(scope.idea.tags.length).toBe(3);
-        scope.idea = {};
-    });
-
-    it('should delete tag', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.removeTag('TestTag2');
-
-        expect(scope.idea.tags.length).not.toBe(2);
-        expect(scope.idea.tags.length).toBe(1);
-        scope.idea = {};
-    });
-
-    it('should not add duplicate tags', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addTag('TestTag2');
-
-        expect(scope.idea.tags.length).not.toBe(3);
-        expect(scope.idea.tags.length).toBe(2);
-    });
-
-    it('should not add more than 5 tags', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2', 'TestTag3', 'TestTag4', 'TestTag5']
-        };
-        scope.addTag('TestTag6');
-
-        expect(scope.idea.tags.length).not.toBe(6);
-        expect(scope.idea.tags.length).toBe(5);
-    });
-
-    it('should not add a blank tag', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addTag('');
-
-        expect(scope.idea.tags.length).not.toBe(3);
-        expect(scope.idea.tags.length).toBe(2);
-    });
-
-    it('should remove special characters from tags', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addTag('hello!@world&*@');
-
-        expect(scope.idea.tags.length).toBe(3);
-        expect(scope.doesTagExist('hello!@world&*@')).toBe(false);
-        expect(scope.doesTagExist('HelloWorld')).toBe(true);
-    });
-
-    it('should use CamelCase for tags', function() {
-        scope.idea = {
-            title: 'Test Title',
-            authorId: 3,
-            description: 'This is a test idea.',
-            tags: ['TestTag1', 'TestTag2']
-        };
-        scope.addTag('This is a tag');
-
-        expect(scope.idea.tags.length).toBe(3);
-        expect(scope.doesTagExist('This is a tag')).toBe(false);
-        expect(scope.doesTagExist('ThisIsATag')).toBe(true);
+            expect(scope.idea.tags.length).not.toBe(2);
+            expect(scope.idea.tags.length).toBe(1);
+            scope.idea = {};
+        });
     });
 });

--- a/src/ideas/addIdeaView/addIdeaView.spec.js
+++ b/src/ideas/addIdeaView/addIdeaView.spec.js
@@ -46,7 +46,7 @@ describe('AddIdeaViewCtrl', function() {
     }));
 
     afterEach(function() {
-        rootScope.$digest();
+        scope.$digest();
     });
 
     it('should exist', function() {
@@ -56,7 +56,7 @@ describe('AddIdeaViewCtrl', function() {
     describe('scope.loadEvents', function() {
         it('should populate the events', function() {
             scope.loadEvents();
-            rootScope.$digest();
+            scope.$digest();
 
             expect(scope.events.length).not.toBe(0);
         });
@@ -67,7 +67,7 @@ describe('AddIdeaViewCtrl', function() {
                 numEvents = response.data.length;
             });
             scope.loadEvents();
-            rootScope.$digest();
+            scope.$digest();
 
             expect(scope.events.length).toBe(numEvents + 1); // appended "None"
         });
@@ -79,7 +79,7 @@ describe('AddIdeaViewCtrl', function() {
             spyOn(console, 'log').and.callFake(function() {});
 
             scope.loadEvents();
-            rootScope.$digest();
+            scope.$digest();
 
             expect(scope.events.length).toBe(0);
             expect(console.log).toHaveBeenCalledWith('FAIL');
@@ -114,7 +114,7 @@ describe('AddIdeaViewCtrl', function() {
 
             scope.addNewIdea(scope.idea);
 
-            rootScope.$digest();
+            scope.$digest();
 
             expect(ideaSvcMock.postIdea).toHaveBeenCalled();
             expect(console.log).toHaveBeenCalledWith('FAIL');

--- a/src/ideas/addIdeaView/addIdeaView.tpl.html
+++ b/src/ideas/addIdeaView/addIdeaView.tpl.html
@@ -18,6 +18,12 @@
                     </div>
                 </md-input-container>
                 <md-input-container>
+                    <label>Event</label>
+                    <md-select placeholder="Select an Event" ng-model="idea.eventId">
+                        <md-option ng-value="event.id" ng-repeat="event in events">{{event.name}}</md-option>
+                    </md-select>
+                </md-input-container>
+                <md-input-container>
                     <label>Description</label>
                     <textarea ng-model="idea.description"
                               name="desc"

--- a/src/ideas/addIdeaView/addIdeaView.tpl.html
+++ b/src/ideas/addIdeaView/addIdeaView.tpl.html
@@ -18,12 +18,6 @@
                     </div>
                 </md-input-container>
                 <md-input-container>
-                    <label>Event</label>
-                    <md-select placeholder="Select an Event" ng-model="idea.eventId">
-                        <md-option ng-value="event.id" ng-repeat="event in events">{{event.name}}</md-option>
-                    </md-select>
-                </md-input-container>
-                <md-input-container>
                     <label>Description</label>
                     <textarea ng-model="idea.description"
                               name="desc"
@@ -37,6 +31,12 @@
                         <div ng-message="minlength">Your description is too short. Must be at least 15 characters</div>
                         <div ng-message="maxlength">Your description is too long</div>
                     </div>
+                </md-input-container>
+                <md-input-container>
+                    <label>Event</label>
+                    <md-select placeholder="Select an Event" md-on-open="loadEvents()" ng-model="idea.eventId">
+                        <md-option ng-value="event._id" ng-repeat="event in events">{{event.name}}</md-option>
+                    </md-select>
                 </md-input-container>
                 <md-input-container class="idea-tags-input-container">
                     <label>Tags</label>

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -120,7 +120,7 @@ angular.module('flintAndSteel')
                     return $q.when({ data: mockIdea });
                 },
                 getIdeaHeaders: function getIdeaHeaders() {
-                    return $q.when({ data:[
+                    return $q.when({ data: [
                         {
                             id: 'mock_idea',
                             title: 'The bestest Idea ever!',

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -120,7 +120,7 @@ angular.module('flintAndSteel')
                     return $q.when({ data: mockIdea });
                 },
                 getIdeaHeaders: function getIdeaHeaders() {
-                    return $q.when([
+                    return $q.when({ data:[
                         {
                             id: 'mock_idea',
                             title: 'The bestest Idea ever!',
@@ -128,7 +128,7 @@ angular.module('flintAndSteel')
                             authorId: 1,
                             likes: 23
                         }
-                    ]);
+                    ]});
                 },
                 postComment: function postComment(parentId, text, authorId) {
                     mockIdea.comments.push(

--- a/src/ideas/ideaSvc/ideaSvc.mock.js
+++ b/src/ideas/ideaSvc/ideaSvc.mock.js
@@ -114,7 +114,7 @@ angular.module('flintAndSteel')
 
             return {
                 postIdea: function postIdea() {
-                    return $q.when({status: 'Created'});
+                    return $q.when({data: {status: 'Created'}});
                 },
                 getIdea: function getIdea() {
                     return $q.when({ data: mockIdea });

--- a/src/ideas/ideasView/ideasView.js
+++ b/src/ideas/ideasView/ideasView.js
@@ -72,9 +72,6 @@ angular.module('flintAndSteel')
                     }
                     else {
                         $scope.idea = response.data;
-                        if (typeof $scope.idea.team === "undefined")	{
-                            $scope.idea.team = [];
-                        }
                         ctrl.enableEdit = false;
                         ctrl.refreshTeam();
                     }

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -159,13 +159,16 @@ describe('IdeasViewCtrl', function() {
             updatesLength = scope.idea.updates.length;
         });
 
+        afterEach(function() {
+            scope.$digest();
+        })
+
         it('should add a new like when the heart outline is clicked', function() {
 
             scope.addNewInteraction('likes');
             ideaSvcMock.getIdea().then(function(response) {
                 expect(response.data.likes.length).toBe(ideaLikes + 1);
             });
-            scope.$digest();
         });
 
         it('should add a new comment when comment is selected', function() {
@@ -177,7 +180,6 @@ describe('IdeasViewCtrl', function() {
                 expect(response.data.comments.length).toBe(commentsLength + 1);
                 expect(response.data.comments[commentsLength].text).toBe('This is a test comment!');
             });
-            scope.$digest();
         });
 
         it('should give a console error if a problem adding comment', function() {
@@ -189,7 +191,6 @@ describe('IdeasViewCtrl', function() {
             scope.addNewInteraction('comments');
             scope.$digest();
             expect(console.log).toHaveBeenCalled();
-            scope.$digest();
         });
 
         it('should add a new back with no tags', function() {
@@ -203,7 +204,6 @@ describe('IdeasViewCtrl', function() {
                 expect(response.data.backs[backsLength].text).toBe('This is a test back!');
                 expect(response.data.backs[backsLength].types.length).toBe(0);
             });
-            scope.$digest();
         });
 
         it('should add a new back with two tags', function() {
@@ -219,7 +219,6 @@ describe('IdeasViewCtrl', function() {
                 expect(response.data.backs[backsLength].types[0].name).toBe('Experience');
                 expect(response.data.backs[backsLength].types[1].name).toBe('Funding');
             });
-            scope.$digest();
         });
 
         it('should add a new update when update is selected', function() {
@@ -231,7 +230,6 @@ describe('IdeasViewCtrl', function() {
                 expect(response.data.updates.length).toBe(updatesLength + 1);
                 expect(response.data.updates[updatesLength].text).toBe('This is a test update!');
             });
-            scope.$digest();
         });
 
         it('should output a console log if problem adding update', function() {
@@ -271,13 +269,16 @@ describe('IdeasViewCtrl', function() {
             updatesLength = scope.idea.updates.length - 1;
         });
 
+        afterEach(function() {
+            scope.$digest();
+        })
+
         it('should remove a new like when the solid heart is clicked', function() {
             scope.removeInteraction('likes');
 
             ideaSvcMock.getIdea().then(function(response) {
                 expect(response.data.likes.length).toBe(ideaLikes);
             });
-            scope.$digest();
         });
 
         it('should remove a specific comment the author posted', function() {
@@ -286,7 +287,6 @@ describe('IdeasViewCtrl', function() {
             ideaSvcMock.getIdea().then(function(response) {
                 expect(response.data.comments.length).toBe(commentsLength);
             });
-            scope.$digest();
         });
 
         it('should remove a specific back the author posted', function() {
@@ -295,7 +295,6 @@ describe('IdeasViewCtrl', function() {
             ideaSvcMock.getIdea().then(function(response) {
                 expect(response.data.backs.length).toBe(backsLength);
             });
-            scope.$digest();
         });
 
         it('should remove a specific update the author posted', function() {
@@ -303,7 +302,6 @@ describe('IdeasViewCtrl', function() {
             ideaSvcMock.getIdea().then(function(response) {
                 expect(response.data.updates.length).toBe(updatesLength);
             });
-            scope.$digest();
         });
 
         it('should output a console log if problem removing like', function() {

--- a/src/ideas/ideasView/ideasView.spec.js
+++ b/src/ideas/ideasView/ideasView.spec.js
@@ -161,7 +161,7 @@ describe('IdeasViewCtrl', function() {
 
         afterEach(function() {
             scope.$digest();
-        })
+        });
 
         it('should add a new like when the heart outline is clicked', function() {
 
@@ -271,7 +271,7 @@ describe('IdeasViewCtrl', function() {
 
         afterEach(function() {
             scope.$digest();
-        })
+        });
 
         it('should remove a new like when the solid heart is clicked', function() {
             scope.removeInteraction('likes');

--- a/src/ideas/ideasView/ideasView.tpl.html
+++ b/src/ideas/ideasView/ideasView.tpl.html
@@ -32,7 +32,7 @@
                         <email-link author-obj="idea.author"></email-link>
                     </h3>
                 </div>
-                <div layout="row" layout-wrap>
+                <div ng-show="idea.eventId !== ''" layout="row" layout-wrap>
                     <span class="custom-chip-wrapper">
                         <small class="custom-chip">{{idea.event.name}}</small>
                     </span>

--- a/src/index.html
+++ b/src/index.html
@@ -55,6 +55,7 @@
   <script src="homeView/timelineEvent/timelineEvent.js"></script>
   <script src="homeView/homeView.js"></script>
   <script src="homeView/helpCard/helpCard.js"></script>
+  <script src="events/eventSvc/eventSvc.js"></script>
   <script src="about/about.js"></script>
   <!-- endinject -->
 

--- a/src/users/accountView/accountView.js
+++ b/src/users/accountView/accountView.js
@@ -29,7 +29,7 @@ angular.module('flintAndSteel')
                 if (userSvc.isUserLoggedIn()) {
                     var userId = userSvc.getProperty('_id');
                     $scope.userIdeas = response.data.filter(function(idea) {
-                        return  userId === idea.authorId;
+                        return userId === idea.authorId;
                     });
                 }
 

--- a/src/users/accountView/accountView.js
+++ b/src/users/accountView/accountView.js
@@ -21,14 +21,16 @@ angular.module('flintAndSteel')
                 };
             }
 
+            $scope.userIdeas = [];
+
             ideaSvc.getIdeaHeaders().then(function getIdeaHeadersSuccess(response) {
-                $scope.userIdeas = [];
 
                 // Find all User Ideas
-                for (var i = 0; i < response.data.length; i++) {  // was let
-                    if (userSvc.isUserLoggedIn() && userSvc.getProperty('_id') === response.data[i].authorId) {
-                        $scope.userIdeas.push(response.data[i]);
-                    }
+                if (userSvc.isUserLoggedIn()) {
+                    var userId = userSvc.getProperty('_id');
+                    $scope.userIdeas = response.data.filter(function(idea) {
+                        return  userId === idea.authorId;
+                    });
                 }
 
             }, function getIdeaHeadersError(response) {

--- a/src/users/accountView/accountView.spec.js
+++ b/src/users/accountView/accountView.spec.js
@@ -40,7 +40,7 @@ describe('AccountViewCtrl', function() {
         }));
 
         afterEach(function() {
-            rootScope.$digest();
+            scope.$digest();
         });
 
         it('should exist', function() {
@@ -74,7 +74,7 @@ describe('AccountViewCtrl', function() {
                 ideaSvc: ideaSvcMock
             });
 
-            rootScope.$digest();
+            scope.$digest();
         }));
 
         it('should exist', function() {

--- a/src/users/accountView/accountView.spec.js
+++ b/src/users/accountView/accountView.spec.js
@@ -9,13 +9,16 @@
 describe('AccountViewCtrl', function() {
     "use strict";
 
-    var scope, ctrl, $state, toastSvc, userSvcMock, ideaSvcMock;
+    var rootScope, scope, ctrl, $state, toastSvc, userSvcMock, ideaSvcMock;
 
     beforeEach(module('flintAndSteel'));
     beforeEach(module('ui.router'));
+    // needed because $state takes us to home by default
+    beforeEach(module('homeView/homeView.tpl.html'));
 
     describe('visiting when not logged in', function() {
         beforeEach(inject(function($rootScope, $controller, _$state_, _toastSvc_, _userSvcMock_, _ideaSvcMock_) {
+            rootScope = $rootScope;
             scope = $rootScope.$new();
             $state = _$state_;
             toastSvc = _toastSvc_;
@@ -36,6 +39,10 @@ describe('AccountViewCtrl', function() {
             });
         }));
 
+        afterEach(function() {
+            rootScope.$digest();
+        })
+
         it('should exist', function() {
             expect(ctrl).toBeDefined();
         });
@@ -47,6 +54,7 @@ describe('AccountViewCtrl', function() {
 
     describe('visiting when logged in', function() {
         beforeEach(inject(function($rootScope, $controller, _$state_, _toastSvc_, _userSvcMock_, _ideaSvcMock_) {
+            rootScope = $rootScope;
             scope = $rootScope.$new();
             $state = _$state_;
             toastSvc = _toastSvc_;
@@ -65,6 +73,8 @@ describe('AccountViewCtrl', function() {
                 userSvc: userSvcMock,
                 ideaSvc: ideaSvcMock
             });
+
+            rootScope.$digest();
         }));
 
         it('should exist', function() {
@@ -73,6 +83,10 @@ describe('AccountViewCtrl', function() {
 
         it('should populate user data if a user is logged in', function() {
             expect(scope.user).toBeDefined();
+        });
+
+        it('should populate user ideas', function() {
+            expect(scope.userIdeas.length).toBe(1);
         });
 
         describe('$scope.logout', function() {

--- a/src/users/accountView/accountView.spec.js
+++ b/src/users/accountView/accountView.spec.js
@@ -41,7 +41,7 @@ describe('AccountViewCtrl', function() {
 
         afterEach(function() {
             rootScope.$digest();
-        })
+        });
 
         it('should exist', function() {
             expect(ctrl).toBeDefined();


### PR DESCRIPTION
## Acceptance Criteria
- [ ] Should be able to select an event when editing an idea
- [x] ~~Should be able to select an event when creating an idea~~
- [x] ~~Event tag should be visible when viewing an idea if the idea is assigned to an event~~

## Coverage
![image](https://cloud.githubusercontent.com/assets/5081281/12373397/1d910fe4-bc46-11e5-81f2-43fce0d335b9.png)

## Demo
![add_event](https://cloud.githubusercontent.com/assets/5081281/12373411/96262cfa-bc46-11e5-8e31-29659bc279dd.gif)

## Notes about the Feature Portion of the PR
I finished having the user able to select an event when creating a new idea. I will get to the idea editing portion at a later date.

There are also some additional checks we can put in place. For instance, no one should be able to tag their idea with an event id that doesn't exist in the database (if the id is empty `""` that's fine though). You wouldn't be able to do this from the UI, but there may be some sneaky ways. What is the risk? The database wouldn't be able to find the specified eventId and would return `EVENT_NOT_FOUND` I think. That may make `replaceIds.js` choke and the idea might not display properly. Or nothing could happen, I'm not sure.

## Notes about general cleanup in this PR
* I made some test specs DRYer by taking repeated code and putting it in a beforeEach
* I added `rootScope.$digest()` to tests that rely on promises being resolved or rejected. Apparently that's needed when testing promises.
* I simplified the logic for finding the users ideas for accountView (currently unused). It now uses `.filter()` instead of looping through and checking manually.



