### PR TITLE
logging for dev, logging to file and skipping noise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ server/secrets
 
 # Code Coverage
 coverage
+
+# Logs
+server/*.log

--- a/server/server.js
+++ b/server/server.js
@@ -54,9 +54,7 @@ if (process.env.NODE_ENV === 'production') {
             stream: logStream,
             skip: function(req) {
                 "use strict";
-                // TODO - Once the API change goes through, this will
-                // become return !/api\/v1\/|sse\//.test(req.originalUrl);
-                return !/ideas|users|events|comments/.test(req.originalUrl);
+                return !/api\/v1\/|sse\//.test(req.originalUrl);
             }
         }
     ));

--- a/server/server.js
+++ b/server/server.js
@@ -32,6 +32,8 @@ if (process.env.NODE_ENV === 'test') {
     port = 7357;
 }
 
+var logStream = fs.createWriteStream(__dirname + '/server.log', { flags: 'a' });
+
 var app = express();
 
 app.use(express.static(path.join(__dirname + '/../src')));
@@ -39,14 +41,24 @@ app.use(bodyParser.json());
 
 if (process.env.NODE_ENV === 'production') {
     process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-    app.use(morgan(':remote-addr - ' +
+
+    app.use(morgan('PROD :remote-addr - ' +
         chalk.cyan('[:date] ') +
         chalk.green('":method :url ') +
         chalk.gray('HTTP/:http-version" ') +
         chalk.yellow(':status ') +
         ':res[content-length] ' +
         chalk.gray('":referrer" ":user-agent" ') +
-        'time=:response-time ms'
+        'time=:response-time ms',
+        {
+            stream: logStream,
+            skip: function(req) {
+                "use strict";
+                // TODO - Once the API change goes through, this will
+                // become return !/api\/v1\/|sse\//.test(req.originalUrl);
+                return !/ideas|users|events|comments/.test(req.originalUrl);
+            }
+        }
     ));
 
     app.use(passport.initialize());
@@ -81,6 +93,12 @@ if (process.env.NODE_ENV === 'production') {
             done("No user provided!");
         }
     });
+}
+else if (process.env.NODE_ENV === 'development') {
+    app.use(morgan('DEV  :method :url :status ' +
+        ':response-time ms - :res[content-length]',
+        { stream: logStream }
+    ));
 }
 
 // routes =============================================================


### PR DESCRIPTION
Enabled logging for dev, all of them going to file obviously. Also only logs when hitting API endpoints in prod. 

Reviewers: @Mctalian, @davethenipper 